### PR TITLE
Add new features: edit/remove ecosystems & projects; add info messages to web UI

### DIFF
--- a/django_bestiary/django_bestiary/templates/base.html
+++ b/django_bestiary/django_bestiary/templates/base.html
@@ -27,9 +27,9 @@
 
         </nav>
         <div class="container-fluid">
-            {% if err != None %}
-            <div class="alert alert-warning alert-dismissible fade show" role="alert">
-                <strong>Ooos!</strong> {{err}}
+            {% if msg != None %}
+            <div class="alert alert-primary alert-dismissible fade show" role="alert">
+                {{ msg }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/django_bestiary/projects/forms.py
+++ b/django_bestiary/projects/forms.py
@@ -30,7 +30,9 @@ class BestiaryEditorForm(forms.Form):
 
     # Hidden widgets to store the state of the BestiaryEditorForm
     eco_name_state = forms.CharField(required=False, max_length=50, widget=forms.HiddenInput())
+    eco_id_state = forms.IntegerField(required=False, widget=forms.HiddenInput())
     projects_state = forms.CharField(required=False, max_length=50, widget=forms.HiddenInput())
+    project_id_state = forms.IntegerField(required=False, widget=forms.HiddenInput())
     data_sources_state = forms.CharField(required=False, max_length=50, widget=forms.HiddenInput())
     repository_views_state = forms.CharField(required=False, max_length=50, widget=forms.HiddenInput())
 
@@ -49,7 +51,9 @@ class BestiaryEditorForm(forms.Form):
         # The state includes the names of objects except for repository_views
         # in which ids are included because there is no name
         self.state_fields = [self['eco_name_state'],
+                             self['eco_id_state'],
                              self['projects_state'],
+                             self['project_id_state'],
                              self['data_sources_state'],
                              self['repository_views_state']
                              ]

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -93,11 +93,11 @@
                       <div class="form-actions pull-right">
                           <div class="input-group">
                               <div id="add-btn-group-eco_modal" class="button-group">
-                                  <button type="submit" formaction='/projects/add_ecosystem' class="btn"><i class="fa fa-plus"></i> Add</button>
+                                  <button type="submit" formaction="/projects/add_ecosystem" class="btn"><i class="fa fa-plus"></i> Add</button>
                               </div>
                               <div id="edit-btn-group-eco_modal" class="button-group">
                                   <button type="submit" formaction="/projects/update_ecosystem" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
-                                  <button type="submit" formaction='/projects/remove_ecosystem' class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
+                                  <button type="submit" formaction="/projects/remove_ecosystem" class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
                               </div>
                           </div>
                       </div>
@@ -137,11 +137,11 @@
                                 <div class="form-actions pull-right">
                                     <div class="input-group">
                                         <div id="add-btn-group-proj_modal" class="button-group">
-                                            <button type="submit" formaction='/projects/add_project' class="btn"><i class="fa fa-plus"></i> Add</button>
+                                            <button type="submit" formaction="/projects/add_project" class="btn"><i class="fa fa-plus"></i> Add</button>
                                         </div>
                                         <div id="edit-btn-group-proj_modal" class="button-group">
                                             <button type="submit" formaction="/projects/update_project" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
-                                            <button type="submit" formaction='/projects/remove_project' class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
+                                            <button type="submit" formaction="/projects/remove_project" class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
                                         </div>
                                     </div>
                                 </div>
@@ -188,11 +188,11 @@
                     <div class="form-actions pull-right">
                         <div class="input-group">
                             <div id="add-btn-group-rv_modal" class="button-group">
-                                <button type="submit" formaction='/projects/add_repository_view' class="btn"><i class="fa fa-plus"></i> Add</button>
+                                <button type="submit" formaction="/projects/add_repository_view" class="btn"><i class="fa fa-plus"></i> Add</button>
                             </div>
                             <div id="edit-btn-group-rv_modal" class="button-group">
-                                <button type="submit" formaction="/projects/update_repository_view" class="btn"><i class="fa fa-save"></i> Save</button>
-                                <button type="submit" formaction='/projects/remove_repository_view' class="btn"><i class="fa fa-trash-o"></i> Remove</button>
+                                <button type="submit" formaction="/projects/update_repository_view" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
+                                <button type="submit" formaction="/projects/remove_repository_view" class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
                             </div>
                         </div>
                     </div>
@@ -209,7 +209,7 @@
     <div class="container-fluid">
       <!-- Start: Editor header -->
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-9">
             <div class="row">
               <form class="form-inline" action="/projects/editor_select_ecosystem" method="post">
                 {% csrf_token %}
@@ -217,17 +217,15 @@
                 {{ field }}
                 {% endfor %}
                 {{ ecosystems_form.name.errors }}
-                <div class="form-group md-2">
-                  <label for="id_name"><h2>Ecosystem:</h2></label>
+                <div class="form-group">
+                  <label for="id_name"> <h3>Ecosystem: </h3></label>
                   {{ ecosystems_form.name }}
                 </div>
               </form>
-              <button id="edit-eco-btn" type="submit" class="btn btn-primary btn-md" onclick="showEditButtons('ecosystems');">
+              <button id="edit-eco-btn" type="submit" class="btn btn-primary" onclick="showEditButtons('ecosystems');">
                 <i class="fa fa-pencil"></i> Edit <span class="sr-only">ecosystem</span>
               </button>
             </div>
-        </div>
-        <div class="col-md-3">
         </div>
         <div class="col-md-3">
           <div class="button-group text-right row">
@@ -425,6 +423,10 @@
             </script>
         {% endif %}
         <script>
+            disableElement("add-project-btn");
+            disableElement("edit-project-btn");
+            disableElement("add-repoView-btn");
+            disableElement("edit-repoView-btn");
             disableElement("add-project-fieldset");
             disableElement("select-project-fieldset");
             disableElement("select-data-source-fieldset");

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -209,38 +209,43 @@
     <div class="container-fluid">
       <!-- Start: Editor header -->
       <div class="row">
-        <div class="col-md-9">
-            <div class="row">
-              <form class="form-inline" action="/projects/editor_select_ecosystem" method="post">
-                {% csrf_token %}
-                {% for field in ecosystems_form.state_fields %}
-                {{ field }}
-                {% endfor %}
-                {{ ecosystems_form.name.errors }}
+        <div class="col-md-2">
+            <form class="form-inline" action="/projects/editor_select_ecosystem" method="post">
+            {% csrf_token %}
+            {% for field in ecosystems_form.state_fields %}
+            {{ field }}
+            {% endfor %}
+            {{ ecosystems_form.name.errors }}
                 <div class="form-group">
-                  <label for="id_name"> <h3>Ecosystem: </h3></label>
-                  {{ ecosystems_form.name }}
+                    <label for="id_name"> <h3>Ecosystem: </h3></label>
+                    {{ ecosystems_form.name }}
                 </div>
-              </form>
-              <button id="edit-eco-btn" type="submit" class="btn btn-primary" onclick="showEditButtons('ecosystems');">
-                <i class="fa fa-pencil"></i> Edit <span class="sr-only">ecosystem</span>
-              </button>
-            </div>
+            </form>
         </div>
-        <div class="col-md-3">
-          <div class="button-group text-right row">
-            <button id="add-eco-btn" type="submit" class="btn btn-primary" onclick="showAddButtons('ecosystems');">
-              <i class="fa fa-plus"></i> Add <span class="sr-only">ecosystem</span>
-            </button>
-            <fieldset id="import-export-eco-fieldset">
-                <button type="submit" class="btn btn-default" data-toggle="modal" data-target="#importModal">
-                  <i class="fa fa-upload"></i> Import <span class="sr-only">ecosystem</span>
-                </button>
-                <button type="submit" class="btn btn-default" data-toggle="modal" data-target="#exportModal">
-                  <i class="fa fa-download"></i> Export <span class="sr-only">ecosystem</span>
-                </button>
-            </fieldset>
-          </div>
+        <div class="col-md-10">
+            <div class="btn-toolbar mb-3" role="toolbar">
+                <div class="btn-group mr-2" role="group">
+                    <fieldset id="add-edit-eco-fieldset">
+                        <button id="add-eco-btn" type="submit" class="btn btn-primary" onclick="showAddButtons('ecosystems');">
+                          <i class="fa fa-plus"></i> Add <span class="sr-only">ecosystem</span>
+                        </button>
+                        <button id="edit-eco-btn" type="submit" class="btn btn-primary" onclick="showEditButtons('ecosystems');">
+                            <i class="fa fa-pencil"></i> Edit <span class="sr-only">ecosystem</span>
+                        </button>
+                    </fieldset>
+                </div>
+
+                <div class="btn-group mr-2" role="group">
+                    <fieldset id="import-export-eco-fieldset">
+                        <button type="submit" class="btn btn-default" data-toggle="modal" data-target="#importModal">
+                            <i class="fa fa-upload"></i> Import <span class="sr-only">ecosystem</span>
+                        </button>
+                        <button type="submit" class="btn btn-default" data-toggle="modal" data-target="#exportModal">
+                            <i class="fa fa-download"></i> Export <span class="sr-only">ecosystem</span>
+                        </button>
+                    </fieldset>
+                </div>
+            </div>
         </div>
       </div>
       <!-- End: Editor header -->
@@ -255,7 +260,7 @@
             <div class="col-sm-4">
               <h3>Projects</h3>
             </div>
-            <div class="col-sm-8">
+            <div class="col-sm-8 text-right">
               <button type="submit" class="btn btn-primary" id="add-project-btn" onclick="showAddButtons('projects');">
                 <i class="fa fa-plus"></i> Add<span class="sr-only"> project</span>
               </button>

--- a/django_bestiary/projects/templates/projects/editor.html
+++ b/django_bestiary/projects/templates/projects/editor.html
@@ -13,11 +13,11 @@
 
 <div class="container-fluid">
   <!-- Modal: Import -->
-  <div class="modal fade" id="importModal" role="dialog">
+  <div class="modal fade" id="importModal" role="dialog" tabindex="-1">
       <div class="modal-dialog">
       <!-- Modal content-->
           <div class="modal-content">
-            <form id="ecosystem_import" method="POST" action="./import/" enctype="multipart/form-data">
+            <form id="ecosystem_import" method="POST" action="/projects/import/" enctype="multipart/form-data">
             {% csrf_token %}
             <div class="modal-header">
                 <div class="modal-title">
@@ -44,11 +44,11 @@
   </div>
 
   <!-- Modal: Download -->
-  <div class="modal fade" id="exportModal" role="dialog">
+  <div class="modal fade" id="exportModal" role="dialog" tabindex="-1">
       <div class="modal-dialog">
       <!-- Modal content-->
           <div class="modal-content">
-            <form id="ecosystem_download" method="POST" action="./export/" enctype="multipart/form-data">{% csrf_token %}
+            <form id="ecosystem_download" method="POST" action="/projects/export/" enctype="multipart/form-data">{% csrf_token %}
             <div class="modal-header">
               <div class="modal-title">Download projects file</div>
               <button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -68,44 +68,60 @@
   </div>
 
   <!-- Modal: Add ecosystem -->
-    <div class="modal fade" id="addEcosystemModal" role="dialog">
+    <div class="modal fade" id="ecoModal" role="dialog" tabindex="-1">
         <div class="modal-dialog">
         <!-- Modal content-->
             <div class="modal-content">
-              <form action="./add_ecosystem" method="post">
+              <form method="post">
                   {% csrf_token %}
-              <div class="modal-header">
-                <div class="modal-title">Add ecosystem</div>
-                <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                  <div class="input-group">
-                      <span class="input-group-addon"><i class="fa fa-globe"></i></span>
-                      {{ ecosystem_form.ecosystem_name }}
+                <fieldset id="eco-fieldset">
+                  <div class="modal-header">
+                    <div class="modal-title">Ecosystem</div>
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
                   </div>
-              </div>
-              <div class="modal-footer">
-                <button type="submit" class="btn btn-primary">Add</button>
-              </div>
+                  <div class="modal-body">
+                      {% for field in ecosystems_form.state_fields %}
+                      {{ field }}
+                      {% endfor %}
+                      {{ ecosystems_form.name.errors }}
+                      <div class="input-group">
+                          <span class="input-group-addon"><i class="fa fa-globe"></i></span>
+                          {{ ecosystem_form.ecosystem_name }}
+                      </div>
+                  </div>
+                  <div class="modal-footer">
+                      <div class="form-actions pull-right">
+                          <div class="input-group">
+                              <div id="add-btn-group-eco_modal" class="button-group">
+                                  <button type="submit" formaction='/projects/add_ecosystem' class="btn"><i class="fa fa-plus"></i> Add</button>
+                              </div>
+                              <div id="edit-btn-group-eco_modal" class="button-group">
+                                  <button type="submit" formaction="/projects/update_ecosystem" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
+                                  <button type="submit" formaction='/projects/remove_ecosystem' class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+                </fieldset>
             </form>
             </div>
         </div>
     </div>
 
   <!-- Modal: Add project -->
-  <div class="modal fade" id="addProjectModal" role="dialog">
+  <div class="modal fade" id="projectsModal" role="dialog" tabindex="-1">
       <div class="modal-dialog">
       <!-- Modal content-->
           <div class="modal-content">
                 <div class="modal-header">
                     <form>
-                        <div class="modal-title">Add project for <strong>{{ ecosystems_form.initial.name }}</strong></div>
+                        <div class="modal-title">Project for <strong>{{ ecosystems_form.initial.name }}</strong></div>
                     </form>
                   <button type="button" class="close" data-dismiss="modal">&times;</button>
                 </div>
                 <div class="container">
-                    <form action="./add_project" method="post" enctype="multipart/form-data">
-                        <fieldset id="add-project">
+                    <form method="post" enctype="multipart/form-data">
+                        <fieldset id="add-project-fieldset">
                             <div class="modal-body">
                                 {% csrf_token %}
                                 {% for field in project_form.state_fields %}
@@ -118,7 +134,17 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                              <button type="submit" class="btn btn-primary">Add project</button>
+                                <div class="form-actions pull-right">
+                                    <div class="input-group">
+                                        <div id="add-btn-group-proj_modal" class="button-group">
+                                            <button type="submit" formaction='/projects/add_project' class="btn"><i class="fa fa-plus"></i> Add</button>
+                                        </div>
+                                        <div id="edit-btn-group-proj_modal" class="button-group">
+                                            <button type="submit" formaction="/projects/update_project" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
+                                            <button type="submit" formaction='/projects/remove_project' class="btn btn-danger"><i class="fa fa-trash-o"></i> Remove</button>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </fieldset>
                     </form>
@@ -128,12 +154,12 @@
   </div>
 
   <!-- Modal: Add data source -->
-  <div class="modal fade" id="DSModal" role="dialog">
+  <div class="modal fade" id="DSModal" role="dialog" tabindex="-1">
       <div class="modal-dialog">
       <!-- Modal content-->
           <div class="modal-content">
             <form method="post">
-                <fieldset id="add-data-source">
+                <fieldset id="add-data-source-fieldset">
                     {% csrf_token %}
                     {% for field in repository_view_form.state_fields %}
                       {{ field }}
@@ -162,11 +188,11 @@
                     <div class="form-actions pull-right">
                         <div class="input-group">
                             <div id="add-btn-group-rv_modal" class="button-group">
-                                <button type="submit" formaction='./add_repository_view' class="btn"><i class="fa fa-plus"></i> Add</button>
+                                <button type="submit" formaction='/projects/add_repository_view' class="btn"><i class="fa fa-plus"></i> Add</button>
                             </div>
                             <div id="edit-btn-group-rv_modal" class="button-group">
-                                <button type="submit" formaction="./update_repository_view" class="btn"><i class="fa fa-save"></i> Save</button>
-                                <button type="submit" formaction='./remove_repository_view' class="btn"><i class="fa fa-trash-o"></i> Remove</button>
+                                <button type="submit" formaction="/projects/update_repository_view" class="btn"><i class="fa fa-save"></i> Save</button>
+                                <button type="submit" formaction='/projects/remove_repository_view' class="btn"><i class="fa fa-trash-o"></i> Remove</button>
                             </div>
                         </div>
                     </div>
@@ -183,28 +209,32 @@
     <div class="container-fluid">
       <!-- Start: Editor header -->
       <div class="row">
-        <div class="col-md-4">
-          <form class="form-inline" action="./editor_select_ecosystem" method="post">
-            {% csrf_token %}
-            {% for field in ecosystems_form.state_fields %}
-            {{ field }}
-            {% endfor %}
-            {{ ecosystems_form.name.errors }}
-            <div class="form-group mb-2">
-              <label for="id_name"><h1>Ecosystem:</h1></label>
-              {{ ecosystems_form.name }}
+        <div class="col-md-6">
+            <div class="row">
+              <form class="form-inline" action="/projects/editor_select_ecosystem" method="post">
+                {% csrf_token %}
+                {% for field in ecosystems_form.state_fields %}
+                {{ field }}
+                {% endfor %}
+                {{ ecosystems_form.name.errors }}
+                <div class="form-group md-2">
+                  <label for="id_name"><h2>Ecosystem:</h2></label>
+                  {{ ecosystems_form.name }}
+                </div>
+              </form>
+              <button id="edit-eco-btn" type="submit" class="btn btn-primary btn-md" onclick="showEditButtons('ecosystems');">
+                <i class="fa fa-pencil"></i> Edit <span class="sr-only">ecosystem</span>
+              </button>
             </div>
-          </form>
         </div>
-        <div class="col-md-5">
-
+        <div class="col-md-3">
         </div>
         <div class="col-md-3">
           <div class="button-group text-right row">
-            <button type="submit" class="btn btn-primary" data-toggle="modal" data-target="#addEcosystemModal">
+            <button id="add-eco-btn" type="submit" class="btn btn-primary" onclick="showAddButtons('ecosystems');">
               <i class="fa fa-plus"></i> Add <span class="sr-only">ecosystem</span>
             </button>
-            <fieldset>
+            <fieldset id="import-export-eco-fieldset">
                 <button type="submit" class="btn btn-default" data-toggle="modal" data-target="#importModal">
                   <i class="fa fa-upload"></i> Import <span class="sr-only">ecosystem</span>
                 </button>
@@ -217,26 +247,30 @@
       </div>
       <!-- End: Editor header -->
     </div>
+
     <div class="container-fluid">
       <!-- Start: Editor body -->
       <div class="row">
         <!-- Start: Projects block -->
         <div class="col-md-2">
           <div class="row">
-            <div class="col-sm-8">
-              <h2>Projects</h2>
-            </div>
             <div class="col-sm-4">
-              <button type="submit" class="btn btn-primary" id="add-project-btn" data-toggle="modal" data-target="#addProjectModal">
+              <h3>Projects</h3>
+            </div>
+            <div class="col-sm-8">
+              <button type="submit" class="btn btn-primary" id="add-project-btn" onclick="showAddButtons('projects');">
                 <i class="fa fa-plus"></i> Add<span class="sr-only"> project</span>
+              </button>
+              <button type="submit" class="btn btn-primary" id="edit-project-btn" onclick="showEditButtons('projects');">
+                <i class="fa fa-pencil"></i> Edit<span class="sr-only"> project</span>
               </button>
             </div>
           </div>
 
           <div class="row">
             <div class="col-sm-12">
-              <form action="./editor_select_project" method="post">
-                <fieldset id="select-project">
+              <form action="/projects/editor_select_project" method="post">
+                <fieldset id="select-project-fieldset">
                     {% csrf_token %}
                     {% for field in projects_form.state_fields %}
                       {{ field }}
@@ -255,44 +289,25 @@
             </div>
           </div>
 
-          <div class="row">
-            <div class="col-sm-12">
-              <h3>Remove project</h3>
-                <form action="./remove_project" method="post">
-                    <fieldset id="remove-project">
-                      {% csrf_token %}
-                      {% for field in project_remove_form.state_fields %}
-                        {{ field }}
-                      {% endfor %}
-                      {{ project_remove_form.name.errors }}
-                        <div class="input-group">
-                            {{ project_remove_form.project_name }}
-                            <button type="submit" class="btn btn-danger" id="remove-project-btn"><span><i class="fa fa-trash-o"></i></span> Remove<span class="sr-only"> project</span></button>
-                        </div>
-                    </fieldset>
-                </form>
-            </div>
-          </div>
-
         </div>
         <!-- End: Projects block -->
         <!-- Start: Data sources block -->
         <div class="col-md-7">
           <div class="row">
             <div class="col-sm-4">
-              <h2>Data Sources</h2>
+              <h3>Data Sources</h3>
             </div>
             <div class="col-sm-8">
               <div class="button-group">
-                <button type="submit" class="btn btn-primary" id="add-repoView-btn" onclick="showAddButtons();"><span><i class="fa fa-plus"></i></span> Add<span class="sr-only"> repository view</span></button>
-                <button type="submit" class="btn btn-primary" id="edit-repoView-btn" onclick="showEditButtons();"><span><i class="fa fa-pencil"></i> Edit<span class="sr-only"> repository view</span></button>
+                <button type="submit" class="btn btn-primary" id="add-repoView-btn" onclick="showAddButtons('data_sources');"><span><i class="fa fa-plus"></i></span> Add<span class="sr-only"> repository view</span></button>
+                <button type="submit" class="btn btn-primary" id="edit-repoView-btn" onclick="showEditButtons('data_sources');"><span><i class="fa fa-pencil"></i> Edit<span class="sr-only"> repository view</span></button>
               </div>
             </div>
           </div>
           <div class="row">
             <div class="col-sm-4">
-                <form action="./select_data_source" method="post">
-                    <fieldset id="select-data-source">
+                <form action="/projects/select_data_source" method="post">
+                    <fieldset id="select-data-source-fieldset">
                       {% csrf_token %}
                       {% for field in data_sources_form.state_fields %}
                         {{ field }}
@@ -308,8 +323,8 @@
                 </form>
             </div>
             <div class="col-sm-8">
-                <form action="./select_repository_view" method="post">
-                    <fieldset id="select-repository-view">
+                <form action="/projects/select_repository_view" method="post">
+                    <fieldset id="select-repository-view-fieldset">
                       {% csrf_token %}
                       {% for field in repository_views_form.state_fields %}
                         {{ field }}
@@ -329,7 +344,7 @@
         <!-- Start: Data sources block -->
         <!-- Start: Scope block -->
         <div class="col-md-3">
-          <h2>Scope</h2>
+          <h3>Scope</h3>
           <table class="table table-hover">
               <tbody>
                 <tr>
@@ -362,16 +377,36 @@
     eco_download_form["name"].removeAttribute("onclick");
 
     // Functions to show/hide buttons on modals depending on the action.
-    function showAddButtons() {
-        document.getElementById("add-btn-group-rv_modal").style.display = "block";
-        document.getElementById("edit-btn-group-rv_modal").style.display = "none";
-        $('#DSModal').modal('show');
+    function showAddButtons(modal_name) {
+        if (modal_name == "ecosystems") {
+            document.getElementById("add-btn-group-eco_modal").style.display = "block";
+            document.getElementById("edit-btn-group-eco_modal").style.display = "none";
+            $('#ecoModal').modal('show');
+        } else if (modal_name == "projects") {
+            document.getElementById("add-btn-group-proj_modal").style.display = "block";
+            document.getElementById("edit-btn-group-proj_modal").style.display = "none";
+            $('#projectsModal').modal('show');
+        } else if (modal_name == "data_sources") {
+            document.getElementById("add-btn-group-rv_modal").style.display = "block";
+            document.getElementById("edit-btn-group-rv_modal").style.display = "none";
+            $('#DSModal').modal('show');
+        }
     }
 
-    function showEditButtons(){
-        document.getElementById("add-btn-group-rv_modal").style.display = "none";
-        document.getElementById("edit-btn-group-rv_modal").style.display = "block";
-        $('#DSModal').modal('show');
+    function showEditButtons(modal_name){
+        if (modal_name == "ecosystems") {
+            document.getElementById("add-btn-group-eco_modal").style.display = "none";
+            document.getElementById("edit-btn-group-eco_modal").style.display = "block";
+            $('#ecoModal').modal('show');
+        } else if (modal_name == "projects") {
+            document.getElementById("add-btn-group-proj_modal").style.display = "none";
+            document.getElementById("edit-btn-group-proj_modal").style.display = "block";
+            $('#projectsModal').modal('show');
+        } else if (modal_name == "data_sources") {
+            document.getElementById("add-btn-group-rv_modal").style.display = "none";
+            document.getElementById("edit-btn-group-rv_modal").style.display = "block";
+            $('#DSModal').modal('show');
+        }
     }
 
     // Disable element
@@ -386,38 +421,38 @@
             <script>
             // If there are no ecosystems, open `add` modal
             // ecosystems length is 1 because of the empty option
-                $('#addEcosystemModal').modal('show');
+                showAddButtons("ecosystems");
             </script>
         {% endif %}
         <script>
-            disableElement("add-project");
-            disableElement("select-project");
-            disableElement("remove-project");
-            disableElement("select-data-source");
-            disableElement("select-repository-view");
-            disableElement("add-data-source");
+            disableElement("add-project-fieldset");
+            disableElement("select-project-fieldset");
+            disableElement("select-data-source-fieldset");
+            disableElement("select-repository-view-fieldset");
+            disableElement("add-data-source-fieldset");
+            disableElement("edit-eco-btn");
         </script>
     {% elif not projects_form.initial.name %}
         {% if projects_form.name|length == 0 %}
             <script>
-                disableElement("select-project");
+                disableElement("select-project-fieldset");
                 // If there are no projects, open `add` modal
-                $('#addProjectModal').modal('show');
+                showAddButtons("projects");
             </script>
         {% endif %}
         <script>
-            disableElement("remove-project");
-            disableElement("select-data-source");
-            disableElement("select-repository-view");
-            disableElement("add-data-source");
+            disableElement("edit-project-btn");
+            disableElement("select-data-source-fieldset");
+            disableElement("select-repository-view-fieldset");
+            disableElement("add-data-source-fieldset");
         </script>
     {% elif not repository_view_form.initial.repository %}
         {% if repository_views_form.id|length == 0 %}
             <script>
-                disableElement("select-data-source");
-                disableElement("select-repository-view");
+                disableElement("select-data-source-fieldset");
+                disableElement("select-repository-view-fieldset");
                 // If there are no data sources, open `add` modal
-                showAddButtons();
+                showAddButtons("data_sources");
             </script>
         {% endif %}
         <script>

--- a/django_bestiary/projects/urls.py
+++ b/django_bestiary/projects/urls.py
@@ -3,12 +3,15 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url(r'^add_ecosystem$', views.add_ecosystem),
+    url(r'^editor_select_ecosystem$', views.editor_select_ecosystem),
     url(r'^import/$', views.import_from_file),
     url(r'^export/ecosystem=(?P<ecosystem>[\w ]+)', views.export_to_file),
     url(r'^export/$', views.export_to_file),
-    url(r'^add_ecosystem$', views.add_ecosystem),
-    url(r'^editor_select_ecosystem$', views.editor_select_ecosystem),
+    url(r'^update_ecosystem$', views.update_ecosystem),
+    url(r'^remove_ecosystem$', views.remove_ecosystem),
     url(r'^add_project$', views.add_project),
+    url(r'^update_project$', views.update_project),
     url(r'^remove_project$', views.remove_project),
     url(r'^editor_select_project$', views.editor_select_project),
     url(r'^add_data_source$', views.add_data_source),

--- a/django_bestiary/projects/views.py
+++ b/django_bestiary/projects/views.py
@@ -24,10 +24,12 @@ from . import data
 
 class EditorState():
 
-    def __init__(self, eco_name=None, projects=[], data_sources=[],
-                 repository_views=[], form=None):
+    def __init__(self, eco_name=None, eco_id=None, projects=[], project_id=None,
+                 data_sources=[], repository_views=[], form=None):
         self.eco_name = eco_name
+        self.eco_id = eco_id
         self.projects = projects
+        self.project_id = project_id
         self.data_sources = data_sources
         self.repository_views = repository_views
 
@@ -39,16 +41,20 @@ class EditorState():
 
             if not self.eco_name:
                 self.eco_name = form.cleaned_data['eco_name_state']
+            if not self.eco_id:
+                self.eco_id = form.cleaned_data['eco_id_state']
             if not self.projects:
                 self.projects = [projects_state] if projects_state else []
+            if not self.project_id:
+                self.project_id = form.cleaned_data['project_id_state']
             if not self.data_sources:
                 self.data_sources = [data_sources] if data_sources else []
             if not self.repository_views:
                 self.repository_views = [repository_views] if repository_views else []
 
     def is_empty(self):
-        return not (self.eco_name or self.projects or self.data_sources or
-                    self.repository_views)
+        return not (self.eco_name or self.eco_id or self.projects or self.project_id or
+                    self.data_sources or self.repository_views)
 
     def initial_state(self):
         """ State to be filled in the forms so it is propagated
@@ -59,7 +65,9 @@ class EditorState():
 
         initial = {
             'eco_name_state': self.eco_name,
+            'eco_id_state': self.eco_id,
             'projects_state': ";".join(self.projects),
+            'project_id_state': self.project_id,
             'data_sources_state': ";".join(self.data_sources),
             "repository_views_state": ";".join([str(repo_view_id) for repo_view_id in self.repository_views])
         }
@@ -91,7 +99,8 @@ def select_project(request, template, context=None):
         if form.is_valid():
             name = form.cleaned_data['name']
             projects = [name]
-            state = EditorState(projects=projects, form=form)
+            project_id = form.cleaned_data['eco_id_state']
+            state = EditorState(projects=projects, project_id=project_id, form=form)
             if context:
                 context.update(build_forms_context(state))
             else:
@@ -112,15 +121,22 @@ def select_ecosystem(request, template, context=None):
         form = forms.EcosystemsForm(request.POST)
         if form.is_valid():
             name = form.cleaned_data['name']
+
             if not name:
                 # TODO: Show error when ecosystem name is empty
                 return shortcuts.render(request, template, build_forms_context())
             # Select and ecosystem reset the state. Don't pass form=form
-            state = build_forms_context(EditorState(eco_name=name))
+            try:
+                eco_orm = Ecosystem.objects.get(name=name)
+            except Ecosystem.DoesNotExist:
+                # TODO: Show error
+                return shortcuts.render(request, template, build_forms_context())
+
+            state = build_forms_context(EditorState(eco_name=name, eco_id=eco_orm.id))
             if context:
                 context.update(state)
             else:
-                context = build_forms_context(EditorState(eco_name=name))
+                context = build_forms_context(EditorState(eco_name=name, eco_id=eco_orm.id))
             return shortcuts.render(request, template, context)
         else:
             # Ignore when the empty option is selected
@@ -138,7 +154,6 @@ def build_forms_context(state=None):
     add_eco_form = forms.EcosystemForm(state=state)
     projects_form = forms.ProjectsForm(state=state)
     project_form = forms.ProjectForm(state=state)
-    project_remove_form = forms.ProjectForm(state=state)
     data_source_form = forms.DataSourceForm(state=state)
     data_sources_form = forms.DataSourcesForm(state=state)
     repository_views_form = forms.RepositoryViewsForm(state=state)
@@ -146,18 +161,19 @@ def build_forms_context(state=None):
 
     if state:
         eco_form.initial['name'] = state.eco_name
+        add_eco_form.initial['id'] = state.eco_id
+        add_eco_form.initial['ecosystem_name'] = state.eco_name
         if state.projects:
             projects_form.initial['name'] = state.projects[0]
-            project_remove_form = forms.ProjectForm(state=state)
-            project_remove_form.initial['project_name'] = state.projects[0]
+            project_form.initial['project_name'] = state.projects[0]
         if state.data_sources:
             data_sources_form.initial['name'] = state.data_sources[0]
+            data_source_form.initial['data_source_name'] = state.data_sources[0]
 
     context = {"ecosystems_form": eco_form,
                "ecosystem_form": add_eco_form,
                "projects_form": projects_form,
                "project_form": project_form,
-               "project_remove_form": project_remove_form,
                "data_source_form": data_source_form,
                "data_sources_form": data_sources_form,
                "repository_views_form": repository_views_form,
@@ -254,10 +270,56 @@ def add_ecosystem(request):
 
             # Select and ecosystem reset the state. Don't pass form=form
             return shortcuts.render(request, 'projects/editor.html',
-                                    build_forms_context(EditorState(eco_name=ecosystem_name)))
+                                    build_forms_context(EditorState(eco_name=ecosystem_name, eco_id=eco_orm.id)))
         else:
             # TODO: Show error
             print("FORM errors", form.errors)
+            raise Http404
+    # if a GET (or any other method) we'll create a blank form
+    else:
+        # TODO: Show error
+        return shortcuts.render(request, 'projects/editor.html', build_forms_context())
+
+
+def update_ecosystem(request):
+    if request.method == 'POST':
+        form = forms.EcosystemForm(request.POST)
+        if form.is_valid():
+            eco_id = form.cleaned_data['eco_id_state']
+            ecosystem_name = form.cleaned_data['ecosystem_name']
+
+            try:
+                eco_orm = Ecosystem.objects.get(id=eco_id)
+            except Ecosystem.DoesNotExist:
+                # TODO: Show error
+                return shortcuts.render(request, 'projects/editor.html', build_forms_context())
+
+            eco_orm.name = ecosystem_name
+            eco_orm.save()
+
+            state = EditorState(eco_name=ecosystem_name, eco_id=eco_id, form=form)
+            return shortcuts.render(request, 'projects/editor.html',
+                                    build_forms_context(state))
+        else:
+            # TODO: Show error
+            print(form.errors)
+            raise Http404
+    # if a GET (or any other method) we'll create a blank form
+    else:
+        # TODO: Show error
+        return shortcuts.render(request, 'projects/editor.html', build_forms_context())
+
+
+def remove_ecosystem(request):
+    if request.method == 'POST':
+        form = forms.EcosystemForm(request.POST)
+        if form.is_valid():
+            ecosystem_name = form.cleaned_data['ecosystem_name']
+            Ecosystem.objects.get(name=ecosystem_name).delete()
+            return shortcuts.render(request, 'projects/editor.html', build_forms_context())
+        else:
+            # TODO: Show error
+            print("remove_ecosystem", form.errors)
             raise Http404
     # if a GET (or any other method) we'll create a blank form
     else:
@@ -443,6 +505,37 @@ def select_data_source(request):
 
 def editor_select_project(request):
     return select_project(request, "projects/editor.html")
+
+
+def update_project(request):
+    if request.method == 'POST':
+        form = forms.ProjectForm(request.POST)
+
+        if form.is_valid():
+            project_id = form.cleaned_data["project_id_state"]
+            project_name = form.cleaned_data["project_name"]
+
+            try:
+                project_orm = Project.objects.get(id=project_id)
+            except Project.DoesNotExist:
+                # TODO: Show error
+                print(form.errors)
+                raise Http404
+
+            project_orm.name = project_name
+            project_orm.save()
+
+            state = EditorState(eco_name=eco_name, projects=[project_name],
+                                project_id=project_id, form=form)
+            return shortcuts.render(request, 'projects/editor.html',
+                                    build_forms_context(state))
+        else:
+            # TODO: Show error
+            raise Http404
+    # if a GET (or any other method) we'll create a blank form
+    else:
+        # TODO: Show error
+        return shortcuts.render(request, 'projects/editor.html', build_forms_context())
 
 
 def remove_project(request):


### PR DESCRIPTION
This PR includes the following changes:

 * Add new features: edit and remove ecosystems and projects using modals.

 * Replace relative URLs in forms for absolute URLs.
   * Although this is not the best option so far, I've decided to make all `formaction` URLs absolutes to avoid problems with `url patterns`.

 * Add support for closing modals using `Esc` key.

 * Add information messages to web UI when perform an important action.
   * By important action I mean: add, edit or remove an ecosystem, a project or a repository view. Also it can tell when a project already exists, so the idea is to extend this functionality in the future so we can show other error messages.

 * Fix `add_project` method
   * If there is a project that belongs to an ecosystem which is removed, that project can be added "as is" to a new ecosystem, printing a warning message.