### PR TITLE
[travis] Support for python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 
 python:
-  - "3.4"
+  - "3.5"
+  - "3.6"
 
 sudo: false
 

--- a/pathfinder/fetch/gerrit.py
+++ b/pathfinder/fetch/gerrit.py
@@ -75,7 +75,7 @@ class GerritFetcher(Fetcher):
                 retries += 1
 
         if stdout is None:
-            raise RuntimeError(' '.join(cmd) + " failed " +
-                               str(self.MAX_RETRIES) + " times. Giving up!")
+            msg = ' '.join(cmd) + " failed " + str(self.MAX_RETRIES) + " times. Giving up!"
+            raise RuntimeError(msg)
 
         return stdout.decode("utf8")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git, __pycache__, build, dist, docs, docker, migrations
-ignore = E129, E402, F841, C901
+ignore = E126, E129, E402, F841, C901, W504
 max-line-length = 135


### PR DESCRIPTION
This code aims at aligning the CI tests across
the different grimoirelab components.

Python 3.4 is removed and Python 3.5 and 3.6 are
now supported.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>