### PR TITLE
[unicorn] Add authentication + transactions log

### DIFF
--- a/bestiary/core/context.py
+++ b/bestiary/core/context.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import collections
+
+
+BestiaryContext = collections.namedtuple('BestiaryContext', ['user'])

--- a/bestiary/core/decorators.py
+++ b/bestiary/core/decorators.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+from django.conf import settings
+from graphql_jwt.decorators import user_passes_test
+
+
+# This custom decorator takes the `user` object from the request's
+# context and checks the value of the `is_authenticated` variable
+# and the `AUTHENTICATION_REQUIRED` variable from the config settings.
+check_auth = user_passes_test(
+    lambda u: u.is_authenticated or not settings.AUTHENTICATION_REQUIRED
+)

--- a/bestiary/core/errors.py
+++ b/bestiary/core/errors.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import enum
+
+
+@enum.unique
+class ErrorCode(enum.Enum):
+    """Error codes for Bestiary"""
+
+    BASE_ERROR = 1
+    ALREADY_EXISTS_ERROR = 2
+    NOT_FOUND_ERROR = 3
+    VALUE_ERROR = 4
+
+
+class BaseError(Exception):
+    """Base class error.
+
+    Derived classes can overwrite error message declaring
+    'message' property.
+    """
+    code = ErrorCode.BASE_ERROR
+    message = "Bestiary unknown error"
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.msg = self.message % kwargs
+
+    def __str__(self):
+        return self.msg
+
+    def __int__(self):
+        return self.code
+
+
+class AlreadyExistsError(BaseError):
+    """Exception raised when an entity already exists in the registry"""
+
+    message = "%(entity)s '%(eid)s' already exists in the registry"
+    code = ErrorCode.ALREADY_EXISTS_ERROR
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.entity = kwargs['entity']
+        self.eid = kwargs['eid']
+
+
+class NotFoundError(BaseError):
+    """Exception raised when an entity is not found in the registry"""
+
+    message = "%(entity)s not found in the registry"
+    code = ErrorCode.NOT_FOUND_ERROR
+
+
+class InvalidValueError(BaseError):
+    """Exception raised when a value is invalid"""
+
+    code = ErrorCode.VALUE_ERROR
+    message = "%(msg)s"

--- a/bestiary/core/errors.py
+++ b/bestiary/core/errors.py
@@ -31,6 +31,7 @@ class ErrorCode(enum.Enum):
     ALREADY_EXISTS_ERROR = 2
     NOT_FOUND_ERROR = 3
     VALUE_ERROR = 4
+    CLOSED_TRANSACTION_ERROR = 5
 
 
 class BaseError(Exception):
@@ -76,4 +77,11 @@ class InvalidValueError(BaseError):
     """Exception raised when a value is invalid"""
 
     code = ErrorCode.VALUE_ERROR
+    message = "%(msg)s"
+
+
+class ClosedTransactionError(BaseError):
+    """Exception raised when performing a change on a closed transaction"""
+
+    code = ErrorCode.CLOSED_TRANSACTION_ERROR
     message = "%(msg)s"

--- a/bestiary/core/log.py
+++ b/bestiary/core/log.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import json
+import re
+import uuid
+
+import django.core.exceptions
+import django.db.utils
+
+from django.contrib.auth.models import User, AnonymousUser
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
+from .context import BestiaryContext
+from .errors import AlreadyExistsError, ClosedTransactionError
+from .models import (Operation,
+                     Transaction)
+from .utils import validate_field
+
+
+class TransactionsLog:
+    """Class for logging transactions and operations related with the database.
+
+    Every object of this class is created using the `open` class method receiving
+    as a parameter the name of the method opening the transaction, which creates a
+    `Transaction` object in the database.
+
+    The method `log_operation` creates a new `Operation` objects linked to the
+    transaction which was generated when the object was instanced. This method
+    receives, among other parameters, the arguments from the method logging the
+    operation in a Python dict object which will be converted to a serialized
+    JSON.
+
+    The `close` method adds a `closed_at` timestamp (before calling this method,
+    this field has a `NULL` value in the DB) and it also sets to `True` the
+    `is_closed` flag.
+
+    :param trx: Transaction object generated with the class method `open`
+
+    :raises ClosedTransactionError: When trying to log an operation on a closed transaction
+    :raises TypeError: When the `op_type` is not an instance of `Operation.OpType` class
+    """
+    def __init__(self, trx, ctx):
+        self.trx = trx
+        self.ctx = ctx
+
+    @classmethod
+    def open(cls, name, ctx):
+        """Create a new transaction object and save it into the DB.
+
+        :param name: Name of the method opening the transaction
+        :param ctx: Context from the method opening the transaction
+
+        :returns: a new TransactionsLog object containing the generated Transaction object
+        """
+        # Check if input values are valid
+        validate_field('name', name)
+        if not isinstance(ctx, BestiaryContext):
+            msg = "ctx value must be a BestiaryContext; {} given".format(ctx.__class__.__name__)
+            raise TypeError(msg)
+        if not isinstance(ctx.user, (User, AnonymousUser)):
+            msg = "ctx.user must be a Django User or AnonymousUser; {} given".format(ctx.__class__.__name__)
+            raise TypeError(msg)
+
+        tuid = uuid.uuid4().hex
+
+        username = None
+        if not isinstance(ctx.user, AnonymousUser):
+            username = ctx.user.username
+            validate_field('username', username)
+
+        trx = Transaction(tuid=tuid,
+                          name=name,
+                          created_at=datetime_utcnow(),
+                          authored_by=username)
+
+        try:
+            trx.save()
+        except django.db.utils.IntegrityError as exc:
+            _handle_integrity_error(Transaction, exc)
+
+        return cls(trx, ctx)
+
+    def close(self):
+        """Close a given transaction adding a timestamp as closing date and setting a flag"""
+
+        self.trx.closed_at = datetime_utcnow()
+        self.trx.is_closed = True
+
+        try:
+            self.trx.save()
+        except django.db.utils.IntegrityError as exc:
+            _handle_integrity_error(Transaction, exc)
+
+    def log_operation(self, op_type, entity_type, timestamp, args, target):
+        """Create a new operation object and save it into the DB.
+
+        :param op_type: Type of the operation which is recorded (ADD, DELETE, UPDATE)
+        :param entity_type: Type of entity involved in the operations
+        :param timestamp: Datetime when the operation is created
+        :param args: Input arguments from the method creating the operation
+        :param target: Argument which the operation is directed to
+
+        :raises ClosedTransactionError: When trying to log an operation on a closed transaction
+        :raises TypeError: When the `op_type` is not an instance of `Operation.OpType` class
+
+        :returns: a new Operation object
+        """
+        if self.trx.is_closed:
+            msg = 'Log operation not allowed, transaction {} is already closed'.format(self.trx.tuid)
+            raise ClosedTransactionError(msg=msg)
+
+        # Check if input values are valid
+        validate_field('entity_type', entity_type)
+        validate_field('target', target)
+        if not isinstance(op_type, Operation.OpType):
+            msg = "'op_type' value must be a 'Operation.OpType'; {} given".format(op_type.__class__.__name__)
+            raise TypeError(msg)
+
+        args_dump = json.dumps(args)
+
+        ouid = uuid.uuid4().hex
+
+        operation = Operation(ouid=ouid, trx=self.trx, op_type=op_type, target=target,
+                              entity_type=entity_type, timestamp=timestamp, args=args_dump)
+
+        try:
+            operation.save()
+        except django.db.utils.IntegrityError as exc:
+            _handle_integrity_error(Operation, exc)
+
+        return operation
+
+
+_MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
+
+
+def _handle_integrity_error(model, exc):
+    """Handle integrity error exceptions."""
+
+    m = re.match(_MYSQL_DUPLICATE_ENTRY_ERROR_REGEX,
+                 exc.__cause__.args[1])
+    if not m:
+        raise exc
+
+    entity = model.__name__
+    eid = m.group('value')
+
+    raise AlreadyExistsError(entity=entity, eid=eid)

--- a/bestiary/core/models.py
+++ b/bestiary/core/models.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import datetime
+
+from dateutil import tz
+
+from django.db.models import (CASCADE,
+                              Model,
+                              BooleanField,
+                              CharField,
+                              DateTimeField,
+                              ForeignKey)
+
+from django_mysql.models import JSONField
+
+from enum import Enum
+
+# Default dates for periods
+MIN_PERIOD_DATE = datetime.datetime(1900, 1, 1, 0, 0, 0,
+                                    tzinfo=tz.tzutc())
+MAX_PERIOD_DATE = datetime.datetime(2100, 1, 1, 0, 0, 0,
+                                    tzinfo=tz.tzutc())
+
+# Innodb and utf8mb4 can only index 191 characters
+# For more information regarding this topic see:
+# https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-conversion.html
+MAX_SIZE_CHAR_INDEX = 191
+MAX_SIZE_CHAR_FIELD = 128
+
+
+class Transaction(Model):
+    """Model class for Transaction objects.
+
+    This class is meant to represent objects which are
+    created inside a context (e.g., a method from the API)
+    where the database is going to be modified in some way.
+
+    Every transaction object must have a unique identifier
+    (`tuid`) and the name of the method creating the
+    transaction (`name`).
+
+    :param tuid: unique identifier for the transaction.
+    :param name: name of the method creating the transaction.
+    :param created_at: datetime when the transaction is created.
+    :param closed_at: datetime when the transaction is closed.
+    :param is_closed: boolean value, `True` if the transaction is closed.
+    :param authored_by: username from who created the transaction.
+    """
+    tuid = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                     primary_key=True,
+                     help_text='Transaction unique identifier')
+    name = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                     help_text='Name of the method creating the transaction')
+    created_at = DateTimeField(help_text='Datetime when the transaction was created')
+    closed_at = DateTimeField(null=True,
+                              help_text='Datetime when the transaction was closed')
+    is_closed = BooleanField(default=False,
+                             help_text='Boolean value, `True` if the transaction is closed')
+    authored_by = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                            null=True,
+                            help_text='Username from who created the transaction')
+
+    class Meta:
+        db_table = 'transactions'
+        ordering = ('created_at', 'tuid')
+
+    def __str__(self):
+        return '%s - %s' % (self.tuid, self.name)
+
+
+class Operation(Model):
+    """Model class for Transaction objects.
+
+    This class is meant to represent atomic interactions
+    with the database (either add, delete or update something)
+    and the entities which are involved in this interaction.
+    An `Operation` object is including the original arguments
+    from the method creating the operation.
+
+    Every operation object must have a unique identifier
+    (`ouid`), its operation type (`ADD`, `DELETE` or `UPDATE`),
+    the type of the entity affected by this operation, the targeted
+    object and the parent transaction where this operation is
+    performed.
+
+    :param ouid: unique identifier for the operation.
+    :param op_type: type of the operation (`ADD`, `DELETE` or `UPDATE`).
+    :param entity_type: type of the entity affected by this operation.
+    :param target: identifier for the main object affected by the
+        operation.
+    :param trx: parent Transaction object.
+    :param timestamp: datetime when this operation is performed.
+    :param args: main input arguments from the method performing the
+        operation. They are serialized in JSON format.
+    """
+    class OpType(Enum):
+        ADD = 'ADD'
+        DELETE = 'DELETE'
+        UPDATE = 'UPDATE'
+
+        @classmethod
+        def choices(cls):
+            return ((item.name, item.value) for item in cls)
+
+        def __str__(self):
+            return self.value
+
+    ouid = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                     primary_key=True,
+                     help_text='Operation unique identifier')
+    op_type = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                        choices=OpType.choices(),
+                        help_text='Operation type (`ADD`, `DELETE` or `UPDATE`)')
+    entity_type = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                            help_text='Type of the main entity involved in the operation')
+    target = CharField(max_length=MAX_SIZE_CHAR_FIELD,
+                       help_text='Identifier of the targeted entity in the operation')
+    trx = ForeignKey(Transaction,
+                     related_name='operations',
+                     on_delete=CASCADE,
+                     db_column='tuid',
+                     help_text='Transaction (context) where this operation is performed')
+    timestamp = DateTimeField(help_text='Datetime when the operation is performed')
+    args = JSONField(help_text='Main input arguments when performing the operation')
+
+    class Meta:
+        db_table = 'operations'
+        ordering = ('timestamp', 'ouid', 'trx')
+
+    def __str__(self):
+        return '%s - %s - %s - %s - %s' % (self.ouid, self.trx, self.op_type, self.entity_type, self.target)

--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import graphene
+import graphql_jwt
+
+
+class BestiaryMutation(graphene.ObjectType):
+    """Mutations supported by Bestiary"""
+
+    # JWT authentication
+    token_auth = graphql_jwt.ObtainJSONWebToken.Field()
+    verify_token = graphql_jwt.Verify.Field()
+    refresh_token = graphql_jwt.Refresh.Field()

--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -20,8 +20,295 @@
 #     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
+import json
+
 import graphene
 import graphql_jwt
+
+from django.conf import settings
+from django.core.paginator import Paginator
+
+from django_mysql.models import JSONField
+
+from graphene.types.generic import GenericScalar
+
+from graphene_django.converter import convert_django_field
+from graphene_django.types import DjangoObjectType
+
+from .decorators import check_auth
+from .models import (Transaction,
+                     Operation)
+
+
+@convert_django_field.register(JSONField)
+def convert_json_field_to_generic_scalar(field, registry=None):
+    """Convert the content of a `JSONField` loading it as an object"""
+
+    return OperationArgsType(description=field.help_text, required=not field.null)
+
+
+class PaginationType(graphene.ObjectType):
+    """Generic type to define pagination information when returning sets of results"""
+
+    class Meta:
+        description = "Generic type to define pagination information when returning sets of results."
+
+    page = graphene.Int(
+        description='Number of the current page'
+    )
+    page_size = graphene.Int(
+        description='Number of results per page'
+    )
+    num_pages = graphene.Int(
+        description='Total number of pages with results'
+    )
+    has_next = graphene.Boolean(
+        description='Boolean value, `True` if exists at least one more page with results'
+    )
+    has_prev = graphene.Boolean(
+        description='Boolean value, `True` if exists at least one previous page with results'
+    )
+    start_index = graphene.Int(
+        description='Starting index of the returned results compared to the total set'
+    )
+    end_index = graphene.Int(
+        description='Final index of the returned results compared to the total set'
+    )
+    total_results = graphene.Int(
+        description='Number of total results'
+    )
+
+
+class OperationArgsType(GenericScalar):
+    """Type including the input arguments from Operation objects loaded from JSON format"""
+
+    class Meta:
+        description = "Operation input arguments in JSON format."
+
+    @classmethod
+    def serialize(cls, value):
+        value = super().serialize(value)
+        value = json.loads(value)
+        return value
+
+
+class OperationType(DjangoObjectType):
+    """Base type for Operation objects as defined in models"""
+
+    class Meta:
+        model = Operation
+        description = "Operation objects representing atomic operations modifying the database."
+
+
+class TransactionType(DjangoObjectType):
+    """Base type for Transaction objects as defined in models"""
+
+    class Meta:
+        model = Transaction
+        description = "Transaction objects representing atomic sets of operations modifying the database."
+
+
+class TransactionFilterType(graphene.InputObjectType):
+    """Fields which can be used as a filter for TransactionPaginatedType objects"""
+
+    class Meta:
+        description = """Use this type to apply filters when retrieving transactions information.
+        Note that these filters are concatenated as `AND` conditions.
+        """
+
+    tuid = graphene.String(
+        required=False,
+        description='Transaction unique id'
+    )
+    name = graphene.String(
+        required=False,
+        description='Name of the method creating the transaction'
+    )
+    is_closed = graphene.Boolean(
+        required=False,
+        description='Boolean value, `True` if the transaction is closed'
+    )
+    from_date = graphene.DateTime(
+        required=False,
+        description='Transactions which creation date is greater or equal'
+    )
+    to_date = graphene.DateTime(
+        required=False,
+        description='Transactions which creation date is less or equal'
+    )
+    authored_by = graphene.String(
+        required=False,
+        description='`username` from the user who created the transaction'
+    )
+
+
+class OperationFilterType(graphene.InputObjectType):
+    """Fields which can be used as a filter for OperationPaginatedType objects"""
+
+    class Meta:
+        description = """Use this type to apply filters when retrieving operations information.
+        Note that these filters are concatenated as `AND` conditions.
+        """
+
+    ouid = graphene.String(
+        required=False,
+        description='Operation unique id'
+    )
+    op_type = graphene.String(
+        required=False,
+        description='Operation type (`ADD`, `DELETE` or `UPDATE`)'
+    )
+    entity_type = graphene.String(
+        required=False,
+        description='Type of the main entity involved in the operation'
+    )
+    target = graphene.String(
+        required=False,
+        description='Identifier of the targeted entity for the operation'
+    )
+    from_date = graphene.DateTime(
+        required=False,
+        description='Operations which creation date is greater or equal'
+    )
+    to_date = graphene.DateTime(
+        required=False,
+        description='Operations which creation date is less or equal'
+    )
+
+
+class AbstractPaginatedType(graphene.ObjectType):
+    """Generic class for objects returning paginated results
+
+    This class aims to represent in a generic way objects
+    which can be returned as a set of paginated results.
+
+    These paginated results will be returned within the `entities`
+    object list. On top of that, the class provides information
+    about the pagination, such as the total number of results
+    or the current cursors referred to the results.
+
+    An `AbstractPaginatedType` object must be created using its
+    constructor method, which receives as input the `QuerySet`
+    object with the results, the number of the page to show
+    and the page size.
+    """
+    @classmethod
+    def create_paginated_result(cls, query, page=1,
+                                page_size=settings.DEFAULT_GRAPHQL_PAGE_SIZE):
+        paginator = Paginator(query, page_size)
+        result = paginator.page(page)
+
+        entities = result.object_list
+
+        page_info = PaginationType(
+            page=result.number,
+            page_size=page_size,
+            num_pages=paginator.num_pages,
+            has_next=result.has_next(),
+            has_prev=result.has_previous(),
+            start_index=result.start_index(),
+            end_index=result.end_index(),
+            total_results=len(query)
+        )
+
+        return cls(entities=entities, page_info=page_info)
+
+
+class TransactionPaginatedType(AbstractPaginatedType):
+    """Type returning paginated results of TransactionType objects"""
+
+    class Meta:
+        description = "Type returning paginated results of TransactionType objects."
+
+    entities = graphene.List(
+        TransactionType,
+        description='List of TransactionType objects'
+    )
+    page_info = graphene.Field(
+        PaginationType,
+        description='Pagination information'
+    )
+
+
+class OperationPaginatedType(AbstractPaginatedType):
+    """Type returning paginated results of OperationType objects."""
+
+    class Meta:
+        description = "Type returning paginated results of OperationType objects."
+
+    entities = graphene.List(
+        OperationType,
+        description='List of OperationType objects'
+    )
+    page_info = graphene.Field(
+        PaginationType,
+        description='Pagination information'
+    )
+
+
+class BestiaryQuery(graphene.ObjectType):
+    """Queries supported by Bestiary"""
+
+    transactions = graphene.Field(
+        TransactionPaginatedType,
+        page_size=graphene.Int(),
+        page=graphene.Int(),
+        filters=TransactionFilterType(required=False)
+    )
+    operations = graphene.Field(
+        OperationPaginatedType,
+        page_size=graphene.Int(),
+        page=graphene.Int(),
+        filters=OperationFilterType(required=False),
+    )
+
+    @check_auth
+    def resolve_transactions(self, info, filters=None,
+                             page=1,
+                             page_size=settings.DEFAULT_GRAPHQL_PAGE_SIZE,
+                             **kwargs):
+        query = Transaction.objects.order_by('created_at')
+
+        if filters and 'tuid' in filters:
+            query = query.filter(tuid=filters['tuid'])
+        if filters and 'name' in filters:
+            query = query.filter(name=filters['name'])
+        if filters and 'is_closed' in filters:
+            query = query.filter(is_closed=filters['isClosed'])
+        if filters and 'from_date' in filters:
+            query = query.filter(created_at__gte=filters['from_date'])
+        if filters and 'to_date' in filters:
+            query = query.filter(created_at__lte=filters['to_date'])
+        if filters and 'authored_by' in filters:
+            query = query.filter(authored_by=filters['authored_by'])
+
+        return TransactionPaginatedType.create_paginated_result(query,
+                                                                page,
+                                                                page_size=page_size)
+
+    @check_auth
+    def resolve_operations(self, info, filters=None,
+                           page=1,
+                           page_size=settings.DEFAULT_GRAPHQL_PAGE_SIZE,
+                           **kwargs):
+        query = Operation.objects.order_by('timestamp')
+
+        if filters and 'ouid' in filters:
+            query = query.filter(ouid=filters['ouid'])
+        if filters and 'op_type' in filters:
+            query = query.filter(op_type=filters['op_type'])
+        if filters and 'entity_type' in filters:
+            query = query.filter(entity_type=filters['entity_type'])
+        if filters and 'target' in filters:
+            query = query.filter(target=filters['target'])
+        if filters and 'from_date' in filters:
+            query = query.filter(timestamp__gte=filters['from_date'])
+        if filters and 'to_date' in filters:
+            query = query.filter(timestamp__lte=filters['to_date'])
+
+        return OperationPaginatedType.create_paginated_result(query,
+                                                              page,
+                                                              page_size=page_size)
 
 
 class BestiaryMutation(graphene.ObjectType):

--- a/bestiary/core/utils.py
+++ b/bestiary/core/utils.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import re
+
+
+def validate_field(name, value, allow_none=False):
+    """Validate a given string field following a set of rules.
+
+    The conditions to validate `value` consists on checking if its value is `None`
+    and if this is allowed or not; if its value is not an empty string or if it is
+    not composed only by whitespaces and/or tabs.
+
+    :param name: name of the field to validate
+    :param value: value of the field to validate
+    :param allow_none: `True` if `None` values are permitted, `False` otherwise
+
+    :raises ValueError: when a condition to validate the string is not satisfied
+    :raises TypeError: when the input value is not a string and not `None`
+    """
+    if value is None:
+        if not allow_none:
+            raise ValueError("'{}' cannot be None".format(name))
+        else:
+            return
+
+    if not isinstance(value, str):
+        msg = "field value must be a string; {} given".format(value.__class__.__name__)
+        raise TypeError(msg)
+
+    if value == '':
+        raise ValueError("'{}' cannot be an empty string".format(name))
+
+    m = re.match(r"^\s+$", value)
+    if m:
+        raise ValueError("'{}' cannot be composed by whitespaces only".format(name))

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import logging
+import graphene
+
+import bestiary.core.schema
+
+
+logging.getLogger("graphql.execution.utils").setLevel(logging.CRITICAL)
+
+schema = graphene.Schema(query=None,
+                         mutation=bestiary.core.schema.BestiaryMutation)

--- a/config/schema.py
+++ b/config/schema.py
@@ -28,5 +28,5 @@ import bestiary.core.schema
 
 logging.getLogger("graphql.execution.utils").setLevel(logging.CRITICAL)
 
-schema = graphene.Schema(query=None,
+schema = graphene.Schema(query=bestiary.core.schema.BestiaryQuery,
                          mutation=bestiary.core.schema.BestiaryMutation)

--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -109,6 +109,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_GRAPHQL_PAGE_SIZE = 10
+
 AUTHENTICATION_BACKENDS = [
     'graphql_jwt.backends.JSONWebTokenBackend',
     'django.contrib.auth.backends.ModelBackend',

--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -1,0 +1,124 @@
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+# Application definition
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'config.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'config.wsgi.application'
+# Password validation
+# https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/2.0/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_TZ = True
+
+USE_I18N = True
+
+USE_L10N = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/2.0/howto/static-files/
+
+STATIC_URL = '/static/'
+
+# Application parameters
+
+SECRET_KEY = 'fake-key'
+
+INSTALLED_APPS = [
+    'bestiary.core',
+    'graphene_django',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'USER': 'root',
+        'PASSWORD': '',
+        'NAME': 'bestiary_db',
+        'TEST': {
+            'NAME': 'testiary',
+            'CHARSET': 'utf8mb4',
+            'COLLATION': 'utf8mb4_unicode_520_ci',
+        }
+    }
+}
+
+AUTHENTICATION_BACKENDS = [
+    'graphql_jwt.backends.JSONWebTokenBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+AUTHENTICATION_REQUIRED = False
+
+GRAPHENE = {
+    'SCHEMA': 'bestiary.core.schema',
+    'MIDDLEWARE': [
+        'graphql_jwt.middleware.JSONWebTokenMiddleware',
+    ],
+}

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -61,6 +61,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_GRAPHQL_PAGE_SIZE = 10
+
 AUTHENTICATION_BACKENDS = [
     'graphql_jwt.backends.JSONWebTokenBackend',
     'django.contrib.auth.backends.ModelBackend',

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -1,0 +1,78 @@
+import logging
+import sys
+
+# Graphene logs Bestiary exceptions and Django prints them
+# to the standard error output. This code prevents Django
+# kind of errors are not shown.
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.CRITICAL)
+
+
+# Application definition
+
+# Internationalization
+# https://docs.djangoproject.com/en/2.0/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_TZ = True
+
+USE_I18N = True
+
+USE_L10N = True
+
+# Application parameters
+
+SECRET_KEY = 'fake-key'
+
+INSTALLED_APPS = [
+    'bestiary.core',
+    'graphene_django',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+]
+
+SQL_MODE = [
+    'ONLY_FULL_GROUP_BY',
+    'NO_ZERO_IN_DATE',
+    'NO_ZERO_DATE',
+    'ERROR_FOR_DIVISION_BY_ZERO',
+    'NO_AUTO_CREATE_USER',
+    'NO_ENGINE_SUBSTITUTION',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'USER': 'root',
+        'PASSWORD': '',
+        'NAME': 'bestiary_db',
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'sql_mode': ','.join(SQL_MODE)
+        },
+        'TEST': {
+            'NAME': 'testiary',
+            'CHARSET': 'utf8mb4',
+            'COLLATION': 'utf8mb4_unicode_520_ci',
+        }
+    }
+}
+
+AUTHENTICATION_BACKENDS = [
+    'graphql_jwt.backends.JSONWebTokenBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
+# This option should be set to True to pass
+# authentication tests.
+AUTHENTICATION_REQUIRED = True
+
+GRAPHENE = {
+    'SCHEMA': 'bestiary.core.schema',
+    'MIDDLEWARE': [
+        'graphql_jwt.middleware.JSONWebTokenMiddleware',
+    ],
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from graphene_django.views import GraphQLView
+
+from .schema import schema
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('graphql/', GraphQLView.as_view(graphiql=True, schema=schema))
 ]

--- a/releases/unreleased/authenticated-queries.yml
+++ b/releases/unreleased/authenticated-queries.yml
@@ -1,0 +1,19 @@
+---
+title: Authenticated queries
+category: added
+author: Miguel Ángel Fernández <mafesan@bitergia.com>
+issue: 35
+notes: >
+    This feature allows to perform authenticated queries
+    to Bestiary. For doing so, a JWT (JSON Web Token)
+    has to be generated and then included within the
+    `Authorization` header in the HTTP requests.
+
+    This feature includes the following methods:
+    * `tokenAuth`: for creating new tokens, taking as input an existing
+    username and its password.
+    * `verifyToken`: for verifying existing tokens.
+    * `refreshToken`: for generating a new valid token from another existing invalid one.
+
+    These methods have to be used with their corresponding
+    GraphQL mutations.

--- a/releases/unreleased/transactions-log.yml
+++ b/releases/unreleased/transactions-log.yml
@@ -1,0 +1,22 @@
+---
+title: Transactions log
+category: added
+author: Miguel Ángel Fernández <mafesan@bitergia.com>
+issue: 36
+notes: >
+    The purpose of this feature is to store in a log
+    each successful operation run by Bestiary adding,
+    deleting or modifying any entity in the database.
+
+    There are new queries allowing to retrieve the
+    information about the transactions and the
+    individual operations in each of these transactions.
+
+    The query getting the transaction objects includes
+    information like the transaction id, its name,
+    its creation date and its author, among other fields.
+
+    The query getting the operation objects includes
+    information like the parent transaction, the operation
+    id, its type, its creation date and its the target
+    entity, among other fields.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 Django==2.1
+grimoirelab_toolkit>=0.1.8
+mysqlclient==1.3.13
+python-dateutil>=2.8.0
 graphene-django>=2.0
 django-mysql>=3.2.0
 django-graphql-jwt>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Django==2.1
+graphene-django>=2.0
+django-graphql-jwt>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==2.1
 graphene-django>=2.0
+django-mysql>=3.2.0
 django-graphql-jwt>=0.3.0

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -138,3 +138,21 @@ class TestInvalidValueError(TestCase):
         """
         kwargs = {}
         self.assertRaises(KeyError, InvalidValueError, **kwargs)
+
+
+class TestClosedTransactionError(TestCase):
+    """Unit tests for ClosedTransactionError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = ClosedTransactionError(msg="transaction already closed")
+        self.assertEqual("transaction already closed", str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, ClosedTransactionError, **kwargs)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+from django.test import TestCase
+
+from bestiary.core.errors import (BaseError,
+                                  AlreadyExistsError,
+                                  NotFoundError,
+                                  InvalidValueError,
+                                  ClosedTransactionError)
+
+
+# Mock classes to test BaseError class
+class MockCode(BaseError):
+    message = "Mock error with code"
+    code = 9314
+
+
+class MockErrorNoArgs(BaseError):
+    message = "Mock error without args"
+
+
+class MockErrorArgs(BaseError):
+    message = "Mock error with args. Error: %(code)s %(msg)s"
+
+
+class TestBaseError(TestCase):
+    """Unit tests for BaseError"""
+
+    def test_int_code_casting(self):
+        """Check if the error can be casted into an error code"""
+
+        e = MockCode()
+        self.assertEqual(int(e), 9314)
+
+    def test_subblass_with_no_args(self):
+        """Check subclasses that do not require arguments.
+
+        Arguments passed to the constructor should be ignored.
+        """
+        e = MockErrorNoArgs(code=1, msg='Fatal error')
+
+        self.assertEqual("Mock error without args", str(e))
+
+    def test_subclass_args(self):
+        """Check subclasses that require arguments"""
+
+        e = MockErrorArgs(code=1, msg='Fatal error')
+
+        self.assertEqual("Mock error with args. Error: 1 Fatal error",
+                         str(e))
+
+    def test_subclass_invalid_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {'code': 1, 'error': 'Fatal error'}
+        self.assertRaises(KeyError, MockErrorArgs, **kwargs)
+
+
+class TestAlreadyExistsError(TestCase):
+    """Unit tests for AlreadyExistsError"""
+
+    def test_message(self):
+        """Make sure it prints the right error"""
+
+        e = AlreadyExistsError(entity='TestEntity', eid='test')
+        self.assertEqual(str(e),
+                         "TestEntity 'test' already exists in the registry")
+
+    def test_args(self):
+        """Test whether attributes are set when they are given as arguments"""
+
+        e = AlreadyExistsError(entity='TestEntity', eid='FFFFFFFFFFF')
+        self.assertEqual(str(e), "TestEntity 'FFFFFFFFFFF' already exists in the registry")
+        self.assertEqual(e.entity, 'TestEntity')
+        self.assertEqual(e.eid, 'FFFFFFFFFFF')
+
+    def test_no_args(self):
+        """Check when required arguments are not given"""
+
+        kwargs = {}
+        self.assertRaises(KeyError, AlreadyExistsError, **kwargs)
+
+
+class TestNotFoundError(TestCase):
+    """Unit tests for NotFoundError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = NotFoundError(entity='TestEntity')
+        self.assertEqual("TestEntity not found in the registry",
+                         str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, NotFoundError, **kwargs)
+
+
+class TestInvalidValueError(TestCase):
+    """Unit tests for InvalidValueError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = InvalidValueError(msg="invalid value")
+        self.assertEqual("invalid value", str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, InvalidValueError, **kwargs)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import collections
+import json
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
+from bestiary.core.context import BestiaryContext
+from bestiary.core.errors import ClosedTransactionError
+from bestiary.core.log import TransactionsLog
+from bestiary.core.models import (Transaction,
+                                  Operation)
+
+OPERATION_TYPE_EMPTY_ERROR = "'op_type' value must be a 'Operation.OpType'; str given"
+OPERATION_TYPE_NONE_ERROR = "'op_type' value must be a 'Operation.OpType'; NoneType given"
+OPERATION_ENTITY_EMPTY_ERROR = "'entity_type' cannot be an empty string"
+OPERATION_ENTITY_NONE_ERROR = "'entity_type' cannot be None"
+OPERATION_TRANSACTION_NONE_ERROR = "field trx must be a Transaction"
+OPERATION_TRANSACTION_CLOSED_ERROR = "Log operation not allowed, transaction {tuid} is already closed"
+TRANSACTION_NAME_EMPTY_ERROR = "'name' cannot be an empty string"
+TRANSACTION_NAME_NONE_ERROR = "'name' cannot be None"
+TRANSACTION_CTX_NONE_ERROR = "ctx value must be a BestiaryContext; NoneType given"
+TRANSACTION_CTX_INVALID_ERROR = "ctx value must be a BestiaryContext; TestTuple given"
+TRANSACTION_CTX_USER_EMPTY_ERROR = "ctx.user must be a Django User or AnonymousUser; BestiaryContext given"
+TRANSACTION_CTX_USER_NONE_ERROR = "ctx.user must be a Django User or AnonymousUser; BestiaryContext given"
+TRANSACTION_CTX_USER_INVALID_ERROR = "ctx.user must be a Django User or AnonymousUser; BestiaryContext given"
+
+
+class TestLogTransaction(TestCase):
+    """Unit tests for add_transaction"""
+
+    def setUp(self):
+        """Load initial values"""
+
+        self.user = get_user_model().objects.create(username='test')
+        self.ctx = BestiaryContext(self.user)
+
+    def test_open_transaction(self):
+        """Check if a new transaction is added"""
+
+        timestamp = datetime_utcnow()
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        self.assertIsInstance(trxl, TransactionsLog)
+
+        trx_db = Transaction.objects.get(tuid=trxl.trx.tuid)
+        self.assertIsInstance(trx_db, Transaction)
+        self.assertEqual(trx_db.name, 'test')
+        self.assertGreater(trx_db.created_at, timestamp)
+        self.assertIsNone(trx_db.closed_at)
+        self.assertEqual(trx_db.authored_by, self.ctx.user.username)
+
+    def test_close_transaction(self):
+        """Check if the transaction gets closed"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        timestamp = datetime_utcnow()
+        trxl.close()
+
+        trx_db = Transaction.objects.get(tuid=trxl.trx.tuid)
+        self.assertGreater(trx_db.closed_at, timestamp)
+
+    def test_name_empty(self):
+        """Check if it fails when `name` field is an empty string"""
+
+        with self.assertRaisesRegex(ValueError, TRANSACTION_NAME_EMPTY_ERROR):
+            TransactionsLog.open('', self.ctx)
+
+    def test_method_name_none(self):
+        """Check if it fails when `method_name` field is `None`"""
+
+        with self.assertRaisesRegex(ValueError, TRANSACTION_NAME_NONE_ERROR):
+            TransactionsLog.open(None, self.ctx)
+
+    def test_context_none(self):
+        """Check if it fails when `ctx` field is `None`"""
+
+        with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_NONE_ERROR):
+            TransactionsLog.open('test', None)
+
+    def test_context_invalid(self):
+        """Check if it fails when `ctx` field is not a BestiaryContext"""
+
+        TestTuple = collections.namedtuple('TestTuple', ['user'])
+        ctx = TestTuple(self.user)
+        with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_INVALID_ERROR):
+            TransactionsLog.open('test', ctx)
+
+    def test_context_anonymous_user(self):
+        """Check if a new transaction is added when the user is anonymous"""
+
+        anon_user = AnonymousUser()
+        ctx = BestiaryContext(anon_user)
+
+        timestamp = datetime_utcnow()
+
+        trxl = TransactionsLog.open('test', ctx)
+        self.assertIsInstance(trxl, TransactionsLog)
+
+        trx_db = Transaction.objects.get(tuid=trxl.trx.tuid)
+        self.assertIsInstance(trx_db, Transaction)
+        self.assertEqual(trx_db.name, 'test')
+        self.assertGreater(trx_db.created_at, timestamp)
+        self.assertIsNone(trx_db.closed_at)
+        self.assertIsNone(trx_db.authored_by)
+
+    def test_context_user_none(self):
+        """Check if it fails when `user` field is `None`"""
+
+        ctx = BestiaryContext(None)
+        with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_USER_NONE_ERROR):
+            TransactionsLog.open('test', ctx)
+
+    def test_context_user_empty(self):
+        """Check if it fails when `user` field is an empty string"""
+
+        ctx = BestiaryContext('')
+        with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_USER_EMPTY_ERROR):
+            TransactionsLog.open('test', ctx)
+
+    def test_context_user_invalid(self):
+        """Check if it fails when `user` field is not an `User` Django object"""
+
+        UserTuple = collections.namedtuple('UserTuple', 'username')
+        user = UserTuple('test')
+
+        ctx = BestiaryContext(user)
+        with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_USER_INVALID_ERROR):
+            TransactionsLog.open('test', ctx)
+
+    def test_log_operation(self):
+        """Check if a new operation is logged"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        input_args = {'test_arg': '12345abcd'}
+
+        operation = trxl.log_operation(op_type=Operation.OpType.ADD, timestamp=datetime_utcnow(),
+                                       entity_type='test_entity', target='test', args=input_args)
+        self.assertIsInstance(operation, Operation)
+
+        operation_db = Operation.objects.get(ouid=operation.ouid)
+        self.assertIsInstance(operation_db, Operation)
+        self.assertEqual(operation_db.op_type, Operation.OpType.ADD.value)
+        self.assertEqual(operation_db.entity_type, 'test_entity')
+        self.assertEqual(operation_db.timestamp, operation.timestamp)
+        self.assertEqual(operation_db.trx, trxl.trx)
+        self.assertEqual(operation_db.target, 'test')
+        self.assertEqual(operation_db.args, json.dumps(input_args))
+        self.assertEqual(input_args, json.loads(operation_db.args))
+
+    def test_log_multiple_operations(self):
+        """Check if multiple operations are logged properly"""
+
+        # Load initial variables
+        trxl = TransactionsLog.open('test', self.ctx)
+        timestamp1 = datetime_utcnow()
+        timestamp2 = datetime_utcnow()
+        input_args1 = {'test_arg': '12345abcd'}
+        input_args2 = {'test_arg': '67890efgh'}
+
+        # Add operations
+        op1 = trxl.log_operation(op_type=Operation.OpType.ADD, timestamp=timestamp1,
+                                 entity_type='test_entity', target='test', args=input_args1)
+        op2 = trxl.log_operation(op_type=Operation.OpType.ADD, timestamp=timestamp2,
+                                 entity_type='test_entity', target='test', args=input_args2)
+
+        # Check number of operations
+        operations = Operation.objects.filter(trx=trxl.trx)
+        self.assertEqual(len(operations), 2)
+
+        # Check op1
+        self.assertIsInstance(op1, Operation)
+
+        operation_db = Operation.objects.get(ouid=op1.ouid)
+        self.assertIsInstance(operation_db, Operation)
+        self.assertEqual(operation_db.op_type, Operation.OpType.ADD.value)
+        self.assertEqual(operation_db.entity_type, 'test_entity')
+        self.assertEqual(operation_db.timestamp, op1.timestamp)
+        self.assertEqual(operation_db.timestamp, timestamp1)
+        self.assertEqual(operation_db.trx, trxl.trx)
+        self.assertEqual(operation_db.target, op1.target)
+        self.assertEqual(operation_db.args, json.dumps(input_args1))
+        self.assertEqual(input_args1, json.loads(operation_db.args))
+
+        # Check op2
+        self.assertIsInstance(op2, Operation)
+
+        operation_db = Operation.objects.get(ouid=op2.ouid)
+        self.assertIsInstance(operation_db, Operation)
+        self.assertEqual(operation_db.op_type, Operation.OpType.ADD.value)
+        self.assertEqual(operation_db.entity_type, 'test_entity')
+        self.assertEqual(operation_db.timestamp, op2.timestamp)
+        self.assertEqual(operation_db.timestamp, timestamp2)
+        self.assertEqual(operation_db.trx, trxl.trx)
+        self.assertEqual(operation_db.target, op2.target)
+        self.assertEqual(operation_db.args, json.dumps(input_args2))
+        self.assertEqual(input_args2, json.loads(operation_db.args))
+
+    def test_log_operation_closed_transaction(self):
+        """Check if it fails when logging an operation on a closed transaction"""
+
+        input_args = json.dumps({'test_arg': '12345abcd'})
+        trxl = TransactionsLog.open('test', self.ctx)
+        tuid = trxl.trx.tuid
+        trxl.close()
+
+        error_msg = OPERATION_TRANSACTION_CLOSED_ERROR.format(tuid=tuid)
+        with self.assertRaisesRegex(ClosedTransactionError, error_msg):
+            trxl.log_operation(op_type=Operation.OpType.UPDATE, entity_type='test_entity',
+                               timestamp=datetime_utcnow(), target='test', args=input_args)
+
+        operations = Operation.objects.filter(trx=trxl.trx)
+        self.assertEqual(len(operations), 0)
+
+    def test_operation_type_empty(self):
+        """Check if it fails when type field is an empty string"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        input_args = json.dumps({'test_arg': '12345abcd'})
+
+        with self.assertRaisesRegex(TypeError, OPERATION_TYPE_EMPTY_ERROR):
+            trxl.log_operation(op_type='', entity_type='test_entity',
+                               timestamp=datetime_utcnow(), target='test', args=input_args)
+
+    def test_operation_type_none(self):
+        """Check if it fails when type field is `None`"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        input_args = json.dumps({'test_arg': '12345abcd'})
+
+        with self.assertRaisesRegex(TypeError, OPERATION_TYPE_NONE_ERROR):
+            trxl.log_operation(op_type=None, entity_type='test_entity',
+                               timestamp=datetime_utcnow(), target='test', args=input_args)
+
+    def test_entity_empty(self):
+        """Check if it fails when entity field is an empty string"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        input_args = json.dumps({'test_arg': '12345abcd'})
+
+        with self.assertRaisesRegex(ValueError, OPERATION_ENTITY_EMPTY_ERROR):
+            trxl.log_operation(op_type=Operation.OpType.ADD, entity_type='',
+                               timestamp=datetime_utcnow(), target='test', args=input_args)
+
+    def test_entity_none(self):
+        """Check if it fails when entity field is `None`"""
+
+        trxl = TransactionsLog.open('test', self.ctx)
+        input_args = json.dumps({'test_arg': '12345abcd'})
+
+        with self.assertRaisesRegex(ValueError, OPERATION_ENTITY_NONE_ERROR):
+            trxl.log_operation(op_type=Operation.OpType.ADD, entity_type=None,
+                               timestamp=datetime_utcnow(), target='test', args=input_args)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import json
+
+from django.db.utils import IntegrityError
+from django.test import TransactionTestCase
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
+from bestiary.core.models import (Transaction,
+                                  Operation)
+
+# Test check errors messages
+DUPLICATE_CHECK_ERROR = "Duplicate entry .+"
+NULL_VALUE_CHECK_ERROR = "Column .+ cannot be null"
+
+
+class TestTransaction(TransactionTestCase):
+    """Unit tests for Transaction class"""
+
+    def test_unique_transactions(self):
+        """Check whether transactions are unique"""
+
+        with self.assertRaisesRegex(IntegrityError, DUPLICATE_CHECK_ERROR):
+            timestamp = datetime_utcnow()
+            Transaction.objects.create(tuid='12345abcd',
+                                       name='test',
+                                       created_at=timestamp,
+                                       authored_by='username')
+            Transaction.objects.create(tuid='12345abcd',
+                                       name='test',
+                                       created_at=timestamp,
+                                       authored_by='username')
+
+    def test_created_at(self):
+        """Check creation date is only set when the object is created"""
+
+        before_dt = datetime_utcnow()
+        trx = Transaction.objects.create(tuid='12345abcd',
+                                         name='test',
+                                         created_at=datetime_utcnow(),
+                                         authored_by='username')
+        after_dt = datetime_utcnow()
+
+        self.assertGreaterEqual(trx.created_at, before_dt)
+        self.assertLessEqual(trx.created_at, after_dt)
+
+        trx.save()
+
+        # Check if creation date does not change after saving the object
+        self.assertGreaterEqual(trx.created_at, before_dt)
+        self.assertLessEqual(trx.created_at, after_dt)
+
+
+class TestOperation(TransactionTestCase):
+    """Unit tests for Operation class"""
+
+    def setUp(self):
+        """Load initial dataset"""
+
+        Transaction.objects.create(tuid='0123456789abcdef',
+                                   name='test', created_at=datetime_utcnow())
+
+    def test_unique_operation(self):
+        """Check whether contexts are unique"""
+
+        timestamp = datetime_utcnow()
+        trx = Transaction.objects.get(tuid='0123456789abcdef')
+        args = json.dumps({'test': 'test_value'})
+
+        with self.assertRaisesRegex(IntegrityError, DUPLICATE_CHECK_ERROR):
+            Operation.objects.create(ouid='12345abcd', op_type=Operation.OpType.ADD,
+                                     entity_type='test_entity', target='test',
+                                     timestamp=timestamp, args=args, trx=trx)
+            Operation.objects.create(ouid='12345abcd', op_type=Operation.OpType.ADD,
+                                     entity_type='test_entity', target='test',
+                                     timestamp=timestamp, args=args, trx=trx)
+
+    def test_created_at(self):
+        """Check creation date is only set when the object is created"""
+
+        trx = Transaction.objects.get(tuid='0123456789abcdef')
+        args = json.dumps({'test': 'test_value'})
+
+        before_dt = datetime_utcnow()
+        operation = Operation.objects.create(ouid='12345abcd', op_type=Operation.OpType.ADD,
+                                             entity_type='test_entity', target='test',
+                                             timestamp=datetime_utcnow(), args=args, trx=trx)
+        after_dt = datetime_utcnow()
+
+        self.assertGreaterEqual(operation.timestamp, before_dt)
+        self.assertLessEqual(operation.timestamp, after_dt)
+
+        operation.save()
+
+        # Check if timestamp does not change after saving the object
+        self.assertGreaterEqual(operation.timestamp, before_dt)
+        self.assertLessEqual(operation.timestamp, after_dt)
+
+    def test_invalid_operation_type_none(self):
+        """Check if an error is raised when the operation type is `None`"""
+
+        trx = Transaction.objects.get(tuid='0123456789abcdef')
+        args = json.dumps({'test': 'test_value'})
+
+        with self.assertRaisesRegex(IntegrityError, NULL_VALUE_CHECK_ERROR):
+            Operation.objects.create(ouid='12345abcd', op_type=None,
+                                     entity_type='test_entity', target='test-target',
+                                     timestamp=datetime_utcnow(), args=args, trx=trx)
+
+    def test_empty_args(self):
+        """Check if an error is raised when no args are set"""
+
+        trx = Transaction.objects.get(tuid='0123456789abcdef')
+
+        with self.assertRaisesRegex(IntegrityError, NULL_VALUE_CHECK_ERROR):
+            Operation.objects.create(ouid='12345abcd', op_type=Operation.OpType.ADD,
+                                     entity_type='test_entity', target='test',
+                                     timestamp=datetime_utcnow(), args=None, trx=trx)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,586 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+import django.test
+import graphene
+import graphene.test
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from grimoirelab_toolkit.datetime import datetime_utcnow, str_to_datetime
+
+from bestiary.core.context import BestiaryContext
+from bestiary.core.log import TransactionsLog
+from bestiary.core.models import (Transaction,
+                                  Operation)
+from bestiary.core.schema import BestiaryQuery, BestiaryMutation
+
+
+AUTHENTICATION_ERROR = "You do not have permission to perform this action"
+
+# Test queries
+BT_TRANSACTIONS_QUERY = """{
+  transactions {
+    entities {
+      name
+      createdAt
+      tuid
+      isClosed
+      closedAt
+      authoredBy
+    }
+  }
+}"""
+BT_TRANSACTIONS_QUERY_FILTER = """{
+  transactions(
+    filters: {
+      tuid: "%s",
+      name: "%s",
+      fromDate: "%s",
+      authoredBy: "%s"
+    }
+  ){
+    entities {
+      name
+      createdAt
+      tuid
+      isClosed
+      closedAt
+      authoredBy
+    }
+  }
+}"""
+BT_TRANSACTIONS_QUERY_PAGINATION = """{
+  transactions(
+    page: %d
+    pageSize: %d
+  ){
+    entities {
+      name
+      createdAt
+      tuid
+      isClosed
+      closedAt
+      authoredBy
+    }
+    pageInfo{
+      page
+      pageSize
+      numPages
+      hasNext
+      hasPrev
+      startIndex
+      endIndex
+      totalResults
+    }
+  }
+}"""
+BT_OPERATIONS_QUERY = """{
+  operations {
+    entities {
+      ouid
+      opType
+      entityType
+      target
+      timestamp
+      args
+      trx{
+        name
+        createdAt
+        tuid
+      }
+    }
+  }
+}"""
+BT_OPERATIONS_QUERY_FILTER = """{
+  operations(
+    filters:{
+      opType:"%s",
+      entityType:"%s",
+      fromDate:"%s"
+    }
+  ){
+    entities {
+      ouid
+      opType
+      entityType
+      target
+      timestamp
+      args
+      trx{
+        name
+        createdAt
+        tuid
+      }
+    }
+  }
+}"""
+BT_OPERATIONS_QUERY_PAGINATION = """{
+  operations(
+    page: %d
+    pageSize: %d
+  ){
+    entities{
+      ouid
+      opType
+      entityType
+      target
+      timestamp
+      args
+      trx{
+        name
+        createdAt
+        tuid
+      }
+    }
+    pageInfo{
+      page
+      pageSize
+      numPages
+      hasNext
+      hasPrev
+      startIndex
+      endIndex
+      totalResults
+    }
+  }
+}"""
+BT_OPERATIONS_QUERY_PAGINATION_NO_PAGE = """{
+  operations(
+    pageSize: %d
+  ){
+    entities{
+      ouid
+      opType
+      entityType
+      target
+      timestamp
+      args
+      trx{
+        name
+        createdAt
+        tuid
+      }
+    }
+    pageInfo{
+      page
+      pageSize
+      numPages
+      hasNext
+      hasPrev
+      startIndex
+      endIndex
+      totalResults
+    }
+  }
+}"""
+BT_OPERATIONS_QUERY_PAGINATION_NO_PAGE_SIZE = """{
+  operations(
+    page: %d
+  ){
+    entities{
+      ouid
+      opType
+      entityType
+      target
+      timestamp
+      args
+      trx{
+        name
+        createdAt
+        tuid
+      }
+    }
+    pageInfo{
+      page
+      pageSize
+      numPages
+      hasNext
+      hasPrev
+      startIndex
+      endIndex
+      totalResults
+    }
+  }
+}"""
+
+# API endpoint to obtain a context for executing queries
+GRAPHQL_ENDPOINT = '/graphql/'
+
+
+class TestQuery(BestiaryQuery, graphene.ObjectType):
+    pass
+
+
+class TestQueryPagination(django.test.TestCase):
+    pass
+
+
+class TestMutations(BestiaryMutation):
+    pass
+
+
+schema = graphene.Schema(query=TestQuery,
+                         mutation=TestMutations)
+
+
+class TestQueryTransactions(django.test.TestCase):
+    """Unit tests for transaction queries"""
+
+    def setUp(self):
+        """Load initial dataset and set queries context"""
+
+        self.user = get_user_model().objects.create(username='test')
+        self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
+        self.context_value.user = self.user
+
+        self.ctx = BestiaryContext(self.user)
+
+        # Create a transaction controlling input values
+        self.timestamp = datetime_utcnow()  # This will be used as a filter
+        self.trx = Transaction(name='test_trx',
+                               tuid='012345abcdef',
+                               created_at=datetime_utcnow(),
+                               authored_by=self.user.username)
+        self.trx.save()
+
+    def test_transaction(self):
+        """Check if it returns the registry of transactions"""
+
+        timestamp = datetime_utcnow()
+        client = graphene.test.Client(schema)
+        executed = client.execute(BT_TRANSACTIONS_QUERY,
+                                  context_value=self.context_value)
+
+        transactions = executed['data']['transactions']['entities']
+        self.assertEqual(len(transactions), 1)
+
+        trx = transactions[0]
+        self.assertEqual(trx['name'], self.trx.name)
+        self.assertEqual(str_to_datetime(trx['createdAt']), self.trx.created_at)
+        self.assertEqual(trx['tuid'], self.trx.tuid)
+        self.assertIsNone(trx['closedAt'])
+        self.assertFalse(trx['isClosed'])
+        self.assertEqual(trx['authoredBy'], 'test')
+
+    def test_filter_registry(self):
+        """Check whether it returns the transaction searched when using filters"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_TRANSACTIONS_QUERY_FILTER % ('012345abcdef', 'test_trx',
+                                                     self.timestamp.isoformat(),
+                                                     'test')
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        transactions = executed['data']['transactions']['entities']
+        self.assertEqual(len(transactions), 1)
+
+        trx = transactions[0]
+        self.assertEqual(trx['name'], self.trx.name)
+        self.assertEqual(str_to_datetime(trx['createdAt']), self.trx.created_at)
+        self.assertEqual(trx['tuid'], self.trx.tuid)
+        self.assertIsNone(trx['closedAt'])
+        self.assertFalse(trx['isClosed'])
+        self.assertEqual(trx['authoredBy'], 'test')
+
+    def test_filter_non_existing_registry(self):
+        """Check whether it returns an empty list when searched with a non existing transaction"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_TRANSACTIONS_QUERY_FILTER % ('012345abcdefg', 'test_trx',
+                                                     self.timestamp.isoformat(),
+                                                     'test')
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        transactions = executed['data']['transactions']['entities']
+        self.assertListEqual(transactions, [])
+
+    def test_pagination(self):
+        """Check whether it returns the transactions searched when using pagination"""
+
+        # Creating additional transactions
+        trx = Transaction(name='test_trx_2',
+                          tuid='567890abcdef',
+                          created_at=datetime_utcnow(),
+                          authored_by=self.user.username,
+                          is_closed=True,
+                          closed_at=datetime_utcnow())
+        trx.save()
+
+        trx = Transaction(name='test_trx_3',
+                          tuid='098765fedcba',
+                          created_at=datetime_utcnow(),
+                          authored_by=self.user.username,
+                          is_closed=True,
+                          closed_at=datetime_utcnow())
+        trx.save()
+
+        timestamp = datetime_utcnow()
+
+        client = graphene.test.Client(schema)
+        test_query = BT_TRANSACTIONS_QUERY_PAGINATION % (1, 2)
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        transactions = executed['data']['transactions']['entities']
+        self.assertEqual(len(transactions), 2)
+
+        trx = transactions[0]
+        self.assertEqual(trx['name'], 'test_trx')
+        self.assertLess(str_to_datetime(trx['createdAt']), timestamp)
+        self.assertEqual(trx['tuid'], '012345abcdef')
+        self.assertIsNone(trx['closedAt'])
+        self.assertFalse(trx['isClosed'])
+        self.assertEqual(trx['authoredBy'], 'test')
+
+        trx = transactions[1]
+        self.assertEqual(trx['name'], 'test_trx_2')
+        self.assertLess(str_to_datetime(trx['createdAt']), timestamp)
+        self.assertEqual(trx['tuid'], '567890abcdef')
+        self.assertLess(str_to_datetime(trx['closedAt']), timestamp)
+        self.assertTrue(trx['isClosed'])
+        self.assertEqual(trx['authoredBy'], 'test')
+
+        pag_data = executed['data']['transactions']['pageInfo']
+        self.assertEqual(len(pag_data), 8)
+        self.assertEqual(pag_data['page'], 1)
+        self.assertEqual(pag_data['pageSize'], 2)
+        self.assertEqual(pag_data['numPages'], 2)
+        self.assertTrue(pag_data['hasNext'])
+        self.assertFalse(pag_data['hasPrev'])
+        self.assertEqual(pag_data['startIndex'], 1)
+        self.assertEqual(pag_data['endIndex'], 2)
+        self.assertEqual(pag_data['totalResults'], 3)
+
+    def test_empty_registry(self):
+        """Check whether it returns an empty list when the registry is empty"""
+
+        # Delete Transactions created in `setUp` method
+        Transaction.objects.all().delete()
+        transactions = Transaction.objects.all()
+
+        self.assertEqual(len(transactions), 0)
+
+        # Test query
+        client = graphene.test.Client(schema)
+        executed = client.execute(BT_TRANSACTIONS_QUERY,
+                                  context_value=self.context_value)
+
+        q_transactions = executed['data']['transactions']['entities']
+        self.assertListEqual(q_transactions, [])
+
+    def test_authentication(self):
+        """Check if it fails when a non-authenticated user executes the query"""
+
+        context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
+        context_value.user = AnonymousUser()
+
+        client = graphene.test.Client(schema)
+
+        executed = client.execute(BT_TRANSACTIONS_QUERY,
+                                  context_value=context_value)
+
+        msg = executed['errors'][0]['message']
+        self.assertEqual(msg, AUTHENTICATION_ERROR)
+
+
+class TestQueryOperations(django.test.TestCase):
+    """Unit tests for operation queries"""
+
+    def setUp(self):
+        """Load initial dataset and set queries context"""
+
+        self.user = get_user_model().objects.create(username='test')
+        self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
+        self.context_value.user = self.user
+
+        self.ctx = BestiaryContext(self.user)
+
+        # Create an operation controlling input values
+        trx = Transaction(name='test_trx',
+                          tuid='012345abcdef',
+                          created_at=datetime_utcnow(),
+                          authored_by=self.user.username)
+        trx.save()
+
+        self.trxl = TransactionsLog(trx, self.ctx)
+        self.timestamp = datetime_utcnow()  # This will be used as a filter
+        self.trxl.log_operation(op_type=Operation.OpType.UPDATE,
+                                entity_type='test_entity',
+                                timestamp=datetime_utcnow(),
+                                args={'test_arg': 'test_value'},
+                                target='test_target')
+        self.trxl.log_operation(op_type=Operation.OpType.ADD,
+                                entity_type='test_entity_2',
+                                timestamp=datetime_utcnow(),
+                                args={'test_arg_2': 'test_value_2'},
+                                target='test_target_2')
+        self.trxl.log_operation(op_type=Operation.OpType.DELETE,
+                                entity_type='test_entity_3',
+                                timestamp=datetime_utcnow(),
+                                args={'test_arg_3': 'test_value_3'},
+                                target='test_target_3')
+        self.trxl.close()
+
+    def test_operation(self):
+        """Check if it returns the registry of operations"""
+
+        client = graphene.test.Client(schema)
+        executed = client.execute(BT_OPERATIONS_QUERY,
+                                  context_value=self.context_value)
+
+        operations = executed['data']['operations']['entities']
+        self.assertEqual(len(operations), 3)
+
+        for op in operations:
+            # Check if the query returns the associated transaction
+            trx = op['trx']
+            self.assertEqual(trx['name'], self.trxl.trx.name)
+            self.assertEqual(trx['tuid'], self.trxl.trx.tuid)
+            self.assertEqual(str_to_datetime(trx['createdAt']), self.trxl.trx.created_at)
+
+        op = operations[0]
+        self.assertEqual(op['opType'], Operation.OpType.UPDATE.value)
+        self.assertEqual(op['entityType'], 'test_entity')
+        self.assertGreater(str_to_datetime(op['timestamp']), self.timestamp)
+        self.assertEqual(op['target'], 'test_target')
+        self.assertEqual(op['args'], {'test_arg': 'test_value'})
+
+        op = operations[1]
+        self.assertEqual(op['opType'], Operation.OpType.ADD.value)
+        self.assertEqual(op['entityType'], 'test_entity_2')
+        self.assertGreater(str_to_datetime(op['timestamp']), self.timestamp)
+        self.assertEqual(op['target'], 'test_target_2')
+        self.assertEqual(op['args'], {'test_arg_2': 'test_value_2'})
+
+        op = operations[2]
+        self.assertEqual(op['opType'], Operation.OpType.DELETE.value)
+        self.assertEqual(op['entityType'], 'test_entity_3')
+        self.assertGreater(str_to_datetime(op['timestamp']), self.timestamp)
+        self.assertEqual(op['target'], 'test_target_3')
+        self.assertEqual(op['args'], {'test_arg_3': 'test_value_3'})
+
+    def test_filter_registry(self):
+        """Check whether it returns the operation searched when using filters"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_OPERATIONS_QUERY_FILTER % ('UPDATE', 'test_entity',
+                                                   self.timestamp.isoformat())
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        operations = executed['data']['operations']['entities']
+        self.assertEqual(len(operations), 1)
+
+        op1 = operations[0]
+        self.assertEqual(op1['opType'], Operation.OpType.UPDATE.value)
+        self.assertEqual(op1['entityType'], 'test_entity')
+        self.assertGreater(str_to_datetime(op1['timestamp']), self.timestamp)
+        self.assertEqual(op1['args'], {'test_arg': 'test_value'})
+
+        # Check if the query returns the associated transaction
+        trx1 = op1['trx']
+        self.assertEqual(trx1['name'], self.trxl.trx.name)
+        self.assertEqual(trx1['tuid'], self.trxl.trx.tuid)
+        self.assertEqual(str_to_datetime(trx1['createdAt']), self.trxl.trx.created_at)
+
+    def test_filter_non_existing_registry(self):
+        """Check whether it returns an empty list when searched with a non existing operation"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_OPERATIONS_QUERY_FILTER % ('DELETE', 'test_entity',
+                                                   self.timestamp.isoformat())
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        operations = executed['data']['operations']['entities']
+        self.assertListEqual(operations, [])
+
+    def test_pagination(self):
+        """Check whether it returns the operations searched when using pagination"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_OPERATIONS_QUERY_PAGINATION % (1, 2)
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        operations = executed['data']['operations']['entities']
+        self.assertEqual(len(operations), 2)
+
+        op1 = operations[0]
+        self.assertEqual(op1['opType'], Operation.OpType.UPDATE.value)
+        self.assertEqual(op1['entityType'], 'test_entity')
+        self.assertGreater(str_to_datetime(op1['timestamp']), self.timestamp)
+        self.assertEqual(op1['args'], {'test_arg': 'test_value'})
+
+        op2 = operations[1]
+        self.assertEqual(op2['opType'], Operation.OpType.ADD.value)
+        self.assertEqual(op2['entityType'], 'test_entity_2')
+        self.assertEqual(op2['target'], 'test_target_2')
+        self.assertGreater(str_to_datetime(op2['timestamp']), self.timestamp)
+        self.assertEqual(op2['args'], {'test_arg_2': 'test_value_2'})
+
+        pag_data = executed['data']['operations']['pageInfo']
+        self.assertEqual(len(pag_data), 8)
+        self.assertEqual(pag_data['page'], 1)
+        self.assertEqual(pag_data['pageSize'], 2)
+        self.assertEqual(pag_data['numPages'], 2)
+        self.assertTrue(pag_data['hasNext'])
+        self.assertFalse(pag_data['hasPrev'])
+        self.assertEqual(pag_data['startIndex'], 1)
+        self.assertEqual(pag_data['endIndex'], 2)
+        self.assertEqual(pag_data['totalResults'], 3)
+
+    def test_empty_registry(self):
+        """Check whether it returns an empty list when the registry is empty"""
+
+        # Delete Operations created in `setUp` method
+        Operation.objects.all().delete()
+        operations = Operation.objects.all()
+
+        self.assertEqual(len(operations), 0)
+
+        # Test query
+        client = graphene.test.Client(schema)
+        executed = client.execute(BT_OPERATIONS_QUERY,
+                                  context_value=self.context_value)
+
+        q_operations = executed['data']['operations']['entities']
+        self.assertListEqual(q_operations, [])
+
+    def test_authentication(self):
+        """Check if it fails when a non-authenticated user executes the query"""
+
+        context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
+        context_value.user = AnonymousUser()
+
+        client = graphene.test.Client(schema)
+
+        executed = client.execute(BT_OPERATIONS_QUERY,
+                                  context_value=context_value)
+
+        msg = executed['errors'][0]['message']
+        self.assertEqual(msg, AUTHENTICATION_ERROR)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+from django.test import TestCase
+
+from bestiary.core.utils import validate_field
+
+
+FIELD_NONE_ERROR = "'{name}' cannot be None"
+FIELD_EMPTY_ERROR = "'{name}' cannot be an empty string"
+FIELD_WHITESPACES_ERROR = "'{name}' cannot be composed by whitespaces only"
+FIELD_TYPE_ERROR = "field value must be a string; int given"
+
+
+class TestValidateField(TestCase):
+    """Unit tests for validate_field"""
+
+    def test_validate_string(self):
+        """Check valid fields"""
+
+        # If the field is valid, the method does not raise any exception
+        validate_field('test_field', 'Test')
+
+    def test_invalid_string(self):
+        """Check invalid string fields"""
+
+        expected = FIELD_EMPTY_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', '')
+
+        expected = FIELD_WHITESPACES_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', '\t')
+
+        expected = FIELD_WHITESPACES_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', '  \t ')
+
+    def test_allow_none(self):
+        """Check valid and invalid fields allowing `None` values"""
+
+        validate_field('test_field', None, allow_none=True)
+
+        expected = FIELD_NONE_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', None, allow_none=False)
+
+        expected = FIELD_EMPTY_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', '', allow_none=True)
+
+        expected = FIELD_WHITESPACES_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', ' \t ', allow_none=True)
+
+    def test_no_string(self):
+        """Check if an exception is raised when the value type is not a string"""
+
+        with self.assertRaisesRegex(TypeError, FIELD_TYPE_ERROR):
+            validate_field('test_field', 42)


### PR DESCRIPTION
About authentication (from issue #35):

After this change, users can perform authenticated queries to Bestiary. For doing so, they must generate a JWT (JSON Web Token) which has to be included within the `Authorization` header in the HTTP requests. 

About transactions log (from issue #36): 

This change includes methods for generating, verifying and refreshing these tokens.

The purpose of this feature is to store in a log each successful operation run by Bestiary adding, deleting or modifying any entity in the database.

---

Note: these two features come together because they couldn't be implemented separately. When trying to implement only the three mutations for setting up authentication coming from graphql_jwt module, it caused the GraphQL endpoint to fail, as there are no queries to show.
