### PR TITLE
Add mutation for removing projects

### DIFF
--- a/bestiary/core/db.py
+++ b/bestiary/core/db.py
@@ -254,6 +254,27 @@ def delete_ecosystem(trxl, ecosystem):
                        target=str(op_args['id']))
 
 
+def delete_project(trxl, project):
+    """Remove an project from the database.
+
+    Function that removes from the database the project
+    given in `project`.
+
+    :param trxl: TransactionsLog object from the method calling this one
+    :param project: project to remove
+    """
+    # Setting operation arguments before they are modified
+    op_args = {
+        'id': project.id
+    }
+
+    project.delete()
+
+    trxl.log_operation(op_type=Operation.OpType.DELETE, entity_type='project',
+                       timestamp=datetime_utcnow(), args=op_args,
+                       target=str(op_args['id']))
+
+
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
 
 

--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -38,7 +38,8 @@ from graphene_django.types import DjangoObjectType
 from .api import (add_ecosystem,
                   add_project,
                   update_ecosystem,
-                  delete_ecosystem)
+                  delete_ecosystem,
+                  delete_project)
 from .context import BestiaryContext
 from .decorators import check_auth
 from .models import (Ecosystem,
@@ -398,6 +399,29 @@ class DeleteEcosystem(graphene.Mutation):
         )
 
 
+class DeleteProject(graphene.Mutation):
+    """Mutation which deletes an existing Project from the registry"""
+
+    class Arguments:
+        id = graphene.ID()
+
+    project = graphene.Field(lambda: ProjectType)
+
+    @check_auth
+    def mutate(self, info, id):
+        user = info.context.user
+        ctx = BestiaryContext(user)
+
+        # Forcing this conversion explicitly, as input value is taken as a string
+        id_value = int(id)
+
+        project = delete_project(ctx, id_value)
+
+        return DeleteProject(
+            project=project
+        )
+
+
 class BestiaryQuery(graphene.ObjectType):
     """Queries supported by Bestiary"""
 
@@ -515,6 +539,7 @@ class BestiaryMutation(graphene.ObjectType):
     add_project = AddProject.Field()
     update_ecosystem = UpdateEcosystem.Field()
     delete_ecosystem = DeleteEcosystem.Field()
+    delete_project = DeleteProject.Field()
 
     # JWT authentication
     token_auth = graphql_jwt.ObtainJSONWebToken.Field()

--- a/releases/unreleased/remove-projects.yml
+++ b/releases/unreleased/remove-projects.yml
@@ -1,0 +1,11 @@
+---
+title: Delete projects
+category: added
+author: Miguel Ángel Fernández <mafesan@bitergia.com>
+issue: 42
+notes: >
+    This feature allows to delete projects from Bestiary.
+
+    There is a new mutation: `deleteProject` which allows
+    to remove projects based on the projects ID.
+


### PR DESCRIPTION
This feature allows to remove Projects from Bestiary.

There is one new mutation: `deleteProject`, which removes an existing project based on its ID.

Note: This PR is part of a set of changes coming from #43 . It depends on the changes from PR #44, where the `Project` model and the method for finding projects are defined.