### PR TITLE
[ui] Implement Ecosystem tree component

### DIFF
--- a/ui/config/storybook/preview-head.html
+++ b/ui/config/storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">

--- a/ui/config/storybook/preview.js
+++ b/ui/config/storybook/preview.js
@@ -1,4 +1,6 @@
 import Vue from "vue";
+import VueRouter from "vue-router";
+import router from "./../../src/router";
 import * as _Vuetify from "vuetify/lib";
 import { configure, addDecorator } from "@storybook/vue";
 
@@ -19,9 +21,10 @@ Vue.use(Vuetify, {
   }
 });
 
-const VuetifyConfig = new Vuetify();
+Vue.use(VueRouter);
 
 addDecorator(() => ({
+  router,
   vuetify: VuetifyConfig,
   template: "<v-app><story/></v-app>"
 }));

--- a/ui/config/storybook/preview.js
+++ b/ui/config/storybook/preview.js
@@ -3,6 +3,7 @@ import VueRouter from "vue-router";
 import router from "./../../src/router";
 import * as _Vuetify from "vuetify/lib";
 import { configure, addDecorator } from "@storybook/vue";
+import '@mdi/font/css/materialdesignicons.css';
 
 const Vuetify = _Vuetify.default;
 
@@ -22,6 +23,20 @@ Vue.use(Vuetify, {
 });
 
 Vue.use(VueRouter);
+
+const VuetifyConfig = new Vuetify({
+  icons: {
+    iconfont: "mdi"
+  },
+  theme: {
+    themes: {
+      light: {
+        primary: "#003756",
+        secondary: "#f4bc00"
+      }
+    }
+  }
+});
 
 addDecorator(() => ({
   router,

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "storybook": "vue-cli-service storybook:serve -p 6006 -c config/storybook"
   },
   "dependencies": {
+    "@mdi/font": "^5.9.55",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link": "^1.2.14",

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,63 +1,23 @@
 <template>
   <v-app>
-    <v-app-bar app color="primary" dark>
-      <div class="d-flex align-center">
-        <v-img
-          alt="Vuetify Logo"
-          class="shrink mr-2"
-          contain
-          src="https://cdn.vuetifyjs.com/images/logos/vuetify-logo-dark.png"
-          transition="scale-transition"
-          width="40"
-        />
-
-        <v-img
-          alt="Vuetify Name"
-          class="shrink mt-1 hidden-sm-and-down"
-          contain
-          min-width="100"
-          src="https://cdn.vuetifyjs.com/images/logos/vuetify-name-dark.png"
-          width="100"
-        />
-      </div>
-
-      <v-spacer></v-spacer>
-
-      <v-btn
-        href="https://github.com/vuetifyjs/vuetify/releases/latest"
-        target="_blank"
-        text
-      >
-        <span class="mr-2">Latest Release</span>
-        <v-icon>mdi-open-in-new</v-icon>
-      </v-btn>
-    </v-app-bar>
-
     <v-main>
-      <v-container>
-        <v-row>
-          <v-col v-for="ecosystem in ecosystems" :key="ecosystem.id" cols="6">
-            <example-card
-              :name="ecosystem.name"
-              :title="ecosystem.title"
-              :description="ecosystem.description"
-            >
-            </example-card>
-          </v-col>
-        </v-row>
-      </v-container>
+      <v-navigation-drawer permanent class="pa-3" color="#F5F5F5">
+        <div v-for="ecosystem in ecosystems" :key="ecosystem.id">
+          <ecosystem-tree :ecosystem="ecosystem" />
+        </div>
+      </v-navigation-drawer>
     </v-main>
   </v-app>
 </template>
 
 <script>
 import { getEcosystems } from "./apollo/queries";
-import ExampleCard from "./components/ExampleCard";
+import EcosystemTree from "./components/EcosystemTree";
 
 export default {
   name: "App",
   components: {
-    ExampleCard
+    EcosystemTree
   },
   data: () => ({
     ecosystems: []

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -1,5 +1,20 @@
 import gql from "graphql-tag";
 
+const projectFragment = gql`
+  fragment projectFields on ProjectType {
+    id
+    name
+    title
+    ecosystem {
+      id
+      name
+    }
+    parentProject {
+      name
+    }
+  }
+`;
+
 const GET_ECOSYSTEMS = gql`
   query GetEcosystems($pageSize: Int, $page: Int) {
     ecosystems(pageSize: $pageSize, page: $page) {
@@ -8,12 +23,25 @@ const GET_ECOSYSTEMS = gql`
         name
         title
         description
+        projectSet {
+          ...projectFields
+          subprojects {
+            ...projectFields
+            subprojects {
+              ...projectFields
+              subprojects {
+                ...projectFields
+              }
+            }
+          }
+        }
       }
       pageInfo {
         totalResults
       }
     }
   }
+  ${projectFragment}
 `;
 
 const getEcosystems = (apollo, pageSize, page) => {

--- a/ui/src/components/EcosystemTree.stories.js
+++ b/ui/src/components/EcosystemTree.stories.js
@@ -1,0 +1,88 @@
+import EcosystemTree from "./EcosystemTree.vue";
+
+export default {
+  title: "EcosystemTree",
+  excludeStories: /.*Data$/
+};
+
+const ecosystemTreeTemplate = '<ecosystem-tree :ecosystem="ecosystem" />';
+
+export const Default = () => ({
+  components: { EcosystemTree },
+  template: ecosystemTreeTemplate,
+  data() {
+    return {
+      ecosystem: {
+        id: 1,
+        name: "ecosystem-name",
+        title: "Ecosystem",
+        projectSet: [
+          {
+            id: "1",
+            name: "projectname",
+            title: "Project 1",
+            ecosystem: {
+              name: "ecosystem-name"
+            },
+            parentProject: null,
+            subprojects: [
+              {
+                id: 2,
+                name: "subproject",
+                title: "Subproject 1",
+                ecosystem: {
+                  name: "ecosystem-name"
+                },
+                parentProject: {
+                  name: "projectname"
+                },
+                subprojects: [
+                  {
+                    id: 3,
+                    name: "sub-subproject",
+                    title: "Sub-subproject title",
+                    ecosystem: {
+                      name: "ecosystem-name"
+                    },
+                    parentProject: {
+                      name: "subproject"
+                    }
+                  }
+                ]
+              },
+              {
+                id: 4,
+                name: "subproject2",
+                title: "Subproject 2",
+                ecosystem: {
+                  name: "ecosystem-name"
+                },
+                parentProject: {
+                  name: "projectname"
+                }
+              }
+            ]
+          },
+          {
+            id: 2,
+            name: "projectname2",
+            title: "Project 2",
+            ecosystem: {
+              name: "ecosystem-name"
+            },
+            parentProject: null
+          },
+          {
+            id: 3,
+            name: "projectname3",
+            title: "Project 3",
+            ecosystem: {
+              name: "ecosystem-name"
+            },
+            parentProject: null
+          }
+        ]
+      }
+    };
+  }
+});

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -1,0 +1,109 @@
+<template>
+  <v-treeview
+    v-if="items"
+    dense
+    hoverable
+    open-all
+    expand-icon="mdi-chevron-down"
+    item-key="name"
+    item-text="title"
+    item-children="subprojects"
+    :items="items"
+  >
+    <template v-slot:label="{ item }">
+      <router-link :to="getLink(item)" @click.native="addActiveClass">
+        {{ item.title }}
+      </router-link>
+    </template>
+  </v-treeview>
+</template>
+
+<script>
+export default {
+  name: "EcosystemTree",
+  props: {
+    ecosystem: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      items: null
+    };
+  },
+  methods: {
+    filterDuplicateProjects(ecosystem) {
+      if (this.ecosystem.projectSet) {
+        const subprojects = this.ecosystem.projectSet.filter(
+          project => !project.parentProject
+        );
+        return [Object.assign(ecosystem, { subprojects })];
+      } else {
+        return [ecosystem];
+      }
+    },
+    getLink(item) {
+      if (item.projectSet) {
+        return `/ecosystem/${item.name}`;
+      } else {
+        return `/ecosystem/${item.ecosystem.name}/project/${item.name}`;
+      }
+    },
+    addActiveClass() {
+      const activeNode = document.querySelector(".v-treeview-node--active");
+      if (activeNode) {
+        activeNode.classList.remove("v-treeview-node--active", "primary--text");
+      }
+      const activeRouterLink = document.querySelector(
+        ".router-link-exact-active"
+      );
+      if (activeRouterLink) {
+        const parent = activeRouterLink.closest(".v-treeview-node__root");
+        parent.classList.add("v-treeview-node--active", "primary--text");
+      }
+    }
+  },
+  mounted() {
+    this.items = this.filterDuplicateProjects(this.ecosystem);
+    this.$nextTick(this.addActiveClass);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_variables";
+.v-treeview-node__root a {
+  font-family: "Roboto", sans-serif;
+  font-size: 0.875rem;
+  color: $text-color;
+  letter-spacing: 0.2px;
+}
+::v-deep .v-treeview-node__children {
+  .theme--light.v-icon,
+  a {
+    color: $text-color--light;
+  }
+}
+.v-treeview-node__label a {
+  text-decoration: none;
+  font-weight: 500;
+}
+.v-treeview-node__root .router-link-exact-active {
+  color: $primary-color;
+  font-weight: 700;
+}
+::v-deep .mdi::before,
+.mdi-set {
+  font-size: 18px;
+}
+::v-deep .v-treeview-node__toggle,
+::v-deep .v-treeview-node__level {
+  width: 18px;
+}
+::v-deep .v-treeview-node--active {
+  .theme--light.v-icon {
+    color: $primary-color;
+  }
+}
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,8 +1,10 @@
 import Vue from "vue";
 import App from "./App.vue";
+import router from "./router";
 import store from "./store";
 import vuetify from "./plugins/vuetify";
 import VueApollo from "vue-apollo";
+import VueRouter from "vue-router";
 import { ApolloClient } from "apollo-client";
 import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
@@ -47,6 +49,7 @@ const apolloClient = new ApolloClient({
 });
 
 Vue.use(VueApollo);
+Vue.use(VueRouter);
 
 const apolloProvider = new VueApollo({
   defaultClient: apolloClient
@@ -55,6 +58,7 @@ const apolloProvider = new VueApollo({
 Vue.config.productionTip = false;
 
 new Vue({
+  router,
   store,
   vuetify,
   apolloProvider,

--- a/ui/src/plugins/vuetify.js
+++ b/ui/src/plugins/vuetify.js
@@ -3,4 +3,18 @@ import Vuetify from "vuetify/lib/framework";
 
 Vue.use(Vuetify);
 
-export default new Vuetify({});
+const opts = {
+  icons: {
+    iconfont: "mdi"
+  },
+  theme: {
+    themes: {
+      light: {
+        primary: "#003756",
+        secondary: "#f4bc00"
+      }
+    }
+  }
+};
+
+export default new Vuetify(opts);

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -1,0 +1,7 @@
+import Router from "vue-router";
+
+const router = new Router({
+  mode: "history"
+});
+
+export default router;

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -1,0 +1,3 @@
+$primary-color: #003756;
+$text-color: #3f3f3f;
+$text-color--light: #7a7a7a;

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -1,0 +1,94 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import VueRouter from 'vue-router';
+import EcosystemTree from "@/components/EcosystemTree";
+
+Vue.use(Vuetify)
+const localVue = createLocalVue();
+localVue.use(Vuetify);
+localVue.use(VueRouter)
+
+describe("EcosystemTree", () => {
+  const router = new VueRouter();
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return mount(EcosystemTree, {
+      localVue,
+      vuetify,
+      router,
+      ...options
+    });
+  };
+
+  const threeLevels = {
+    id: 0,
+    name: "root",
+    title: "root",
+    projectSet: [
+      {
+        id: 1,
+        name: "child",
+        title: "child",
+        parentProject: null,
+        ecosystem: {
+          name: "root"
+        },
+        subprojects: [{
+          id: 2,
+          name: "grandchild",
+          title: "grandchild",
+          parentProject: {
+            name: "child"
+          },
+          ecosystem: {
+            name: "root"
+          }
+        }]
+      },
+      {
+        id: 2,
+        name: "grandchild",
+        title: "grandchild",
+        parentProject: {
+          name: "child"
+        },
+        ecosystem: {
+          name: "root"
+        }
+      }
+    ]
+  };
+
+  test("Filters subprojects at projectSet level", () => {
+    const wrapper = mountFunction({
+      propsData: {
+        ecosystem: threeLevels
+      }
+    });
+
+    const children = wrapper.vm.items[0].subprojects;
+    expect(children.length).toBe(1);
+  });
+
+  test("Generates links", () => {
+    const wrapper = mountFunction({
+      propsData: {
+        ecosystem: threeLevels
+      }
+    });
+
+    const ecosystemLink = wrapper.vm.getLink(wrapper.vm.ecosystem);
+    expect(ecosystemLink).toBe("/ecosystem/root");
+
+    const projectLink = wrapper.vm.getLink(
+      wrapper.vm.ecosystem.subprojects[0]
+    );
+    expect(projectLink).toBe("/ecosystem/root/project/child");
+
+    const subprojectLink = wrapper.vm.getLink(
+      wrapper.vm.ecosystem.subprojects[0].subprojects[0]
+    );
+    expect(subprojectLink).toBe("/ecosystem/root/project/grandchild");
+  })
+});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1384,6 +1384,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@mdi/font@^5.9.55":
+  version "5.9.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
+  integrity sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg==
+
 "@mdx-js/loader@^1.6.19":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"


### PR DESCRIPTION
Creates the `EcosystemTree` component, which uses Vuetify's `treeview` to display an ecosystem's project structure and hierarchy following the wireframe on #50. Each tree node links to the project's page using `vue-router` (the views it links to are yet to be developed).
Examples of the component can be found on Storybook, using mock data; and on the app's sidebar, using a GraphQL query to retrieve the ecosystems in the database.