### PR TITLE
[ui] Implement project view

### DIFF
--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -55,6 +55,26 @@ const GET_PROJECTS = gql`
   }
 `;
 
+const GET_PROJECT_BY_NAME = gql`
+  query getProjectById($filters: ProjectFilterType) {
+    projects(pageSize: 1, page: 1, filters: $filters) {
+      entities {
+        ...projectFields
+        subprojects {
+          ...projectFields
+          subprojects {
+            ...projectFields
+            subprojects {
+              ...projectFields
+            }
+          }
+        }
+      }
+    }
+  }
+  ${projectFragment}
+`;
+
 const getEcosystems = (apollo, pageSize, page) => {
   const response = apollo.query({
     query: GET_ECOSYSTEMS,
@@ -79,4 +99,18 @@ const getProjects = (apollo, pageSize, page, filters) => {
   return response;
 };
 
-export { getEcosystems, getProjects };
+const getProjectByName = (apollo, name, ecosystemId) => {
+  const response = apollo.query({
+    query: GET_PROJECT_BY_NAME,
+    variables: {
+      filters: {
+        ecosystemId: ecosystemId,
+        name: name
+      }
+    },
+    fetchPolicy: "no-cache"
+  });
+  return response;
+};
+
+export { getEcosystems, getProjects, getProjectByName };

--- a/ui/src/components/ProjectForm.vue
+++ b/ui/src/components/ProjectForm.vue
@@ -32,6 +32,7 @@
           label="Parent project (optional)"
           item-text="title"
           item-value="id"
+          clearable
           outlined
           dense
           @click.once="loadParentProjects"
@@ -73,6 +74,11 @@ export default {
     addProject: {
       type: Function,
       required: true
+    },
+    parent: {
+      type: Object,
+      required: false,
+      default: null
     }
   },
   data() {
@@ -119,6 +125,12 @@ export default {
           path: `/ecosystem/${this.ecosystemId}/project/${projectName}`
         });
       }
+    }
+  },
+  created() {
+    if (this.parent) {
+      this.loadParentProjects();
+      this.parentId = this.parent.id;
     }
   }
 };

--- a/ui/src/components/ProjectList.stories.js
+++ b/ui/src/components/ProjectList.stories.js
@@ -1,0 +1,90 @@
+import ProjectList from "./ProjectList.vue";
+
+export default {
+  title: "ProjectList",
+  excludeStories: /.*Data$/
+};
+
+const ProjectListTemplate = `
+  <project-list
+    :projects="projects"
+    ecosystemId="1"
+    :parent-project="parentProject"
+  />
+`;
+
+export const Default = () => ({
+  components: { ProjectList },
+  template: ProjectListTemplate,
+  data() {
+    return {
+      projects: [
+        {
+          id: 2,
+          name: "beast",
+          title: "Beast",
+          ecosystem: {
+            id: 1
+          },
+          subprojects: [
+            {
+              id: 3,
+              name: "dragon",
+              title: "Dragon",
+              ecosystem: {
+                id: 1
+              },
+              subprojects: [
+                {
+                  id: 5,
+                  name: "longhorn",
+                  title: "Romanian Longhorn",
+                  ecosystem: {
+                    id: 1
+                  },
+                  subprojects: []
+                }
+              ]
+            },
+            {
+              id: 6,
+              name: "unicorn",
+              title: "Unicorn",
+              ecosystem: {
+                id: 1
+              },
+              subprojects: []
+            }
+          ]
+        },
+        {
+          id: 4,
+          name: "goblin",
+          title: "Goblin",
+          ecosystem: {
+            id: 1
+          },
+          subprojects: []
+        }
+      ],
+      parentProject: {
+        id: 1,
+        name: "name"
+      }
+    };
+  }
+});
+
+export const Empty = () => ({
+  components: { ProjectList },
+  template: ProjectListTemplate,
+  data() {
+    return {
+      projects: [],
+      parentProject: {
+        id: 1,
+        name: "name"
+      }
+    };
+  }
+});

--- a/ui/src/components/ProjectList.vue
+++ b/ui/src/components/ProjectList.vue
@@ -1,0 +1,114 @@
+<template>
+  <section>
+    <div class="d-flex justify-space-between">
+      <h3 class="text-h6 d-flex align-center">
+        Projects
+        <v-chip small pill class="ml-2">{{ list.length }}</v-chip>
+      </h3>
+      <v-btn
+        color="#D7DDE1"
+        class="primary--text button"
+        :to="{
+          name: 'project-new',
+          params: {
+            id: ecosystemId,
+            parent: parentProject
+          }
+        }"
+      >
+        <v-icon dense left>mdi-plus</v-icon>
+        Add project
+      </v-btn>
+    </div>
+    <v-list two-line>
+      <router-link
+        v-for="project in list"
+        :key="project.id"
+        :to="project.route"
+        custom
+        v-slot="{ href, route, navigate }"
+      >
+        <v-list-item :href="href" @click="navigate">
+          <v-list-item-content>
+            <v-list-item-title v-html="highlightName(project.path)" />
+            <v-list-item-subtitle>{{ project.title }}</v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+      </router-link>
+    </v-list>
+  </section>
+</template>
+
+<script>
+export default {
+  name: "ProjectList",
+  props: {
+    projects: {
+      type: Array,
+      required: true
+    },
+    ecosystemId: {
+      type: [Number, String],
+      required: true
+    },
+    parentProject: {
+      type: Object,
+      required: false
+    }
+  },
+  data() {
+    return {
+      list: []
+    };
+  },
+  methods: {
+    flattenProjects(projects, prefix) {
+      let result = [];
+      prefix = prefix ? `${prefix} / ` : " ";
+      projects.forEach(project => {
+        const path = `${prefix}${project.name}`;
+        const route = `/ecosystem/${project.ecosystem.id}/project/${project.name}`;
+        result.push(Object.assign(project, { path, route }));
+        if (Array.isArray(project.subprojects)) {
+          result = result.concat(
+            this.flattenProjects(project.subprojects, path)
+          );
+        } else {
+          result = result.concat(Object.assign(project, { path, route }));
+        }
+      });
+      return result;
+    },
+    highlightName(route) {
+      let names = route.split("/");
+      if (names.length === 1) {
+        return `<span>${route}</span>`;
+      } else {
+        const last = names.pop();
+        return `${[...names].join(" / ")} / <span>${last}</span>`;
+      }
+    }
+  },
+  watch: {
+    projects(value) {
+      this.list = this.flattenProjects(value);
+    }
+  },
+  mounted() {
+    this.list = this.flattenProjects(this.projects);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+::v-deep .v-list-item__title span {
+  font-weight: 500;
+}
+.button {
+  text-transform: none;
+  letter-spacing: normal;
+}
+.v-list-item:not(:last-child) {
+  border-bottom: thin solid rgba(0, 0, 0, 0.12);
+}
+</style>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -8,6 +8,12 @@ const router = new Router({
       path: "/ecosystem/:id/new",
       component: () => import("../views/NewProject"),
       props: true
+    },
+    {
+      name: "project",
+      path: "/ecosystem/:ecosystemId/project/:name",
+      component: () => import("../views/Project"),
+      props: true
     }
   ]
 });

--- a/ui/src/views/NewProject.vue
+++ b/ui/src/views/NewProject.vue
@@ -9,6 +9,7 @@
       :ecosystemId="ecosystemId"
       :get-projects="getProjects"
       :add-project="addProject"
+      :parent="parent"
     />
     <v-alert v-else text outlined type="error" width="50%">
       No ecosystem with id <code>{{ this.$route.params.id }}</code>
@@ -30,6 +31,9 @@ export default {
     },
     isEcosystem() {
       return this.$store.getters.findEcosystem(this.ecosystemId);
+    },
+    parent() {
+      return this.$route.params.parent;
     }
   },
   methods: {

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="pa-5" v-if="project">
+    <nav class="text-body-1 font-weight-light mb-9">
+      Bestiary / {{ project.ecosystem.name }} /
+      <span v-if="project.parentProject">
+        {{ project.parentProject.name }} /
+      </span>
+      <span class="font-weight-bold">{{ project.name }}</span>
+    </nav>
+
+    <h2 class="text-h5 font-weight-medium mb-9">{{ project.title }}</h2>
+
+    <project-list
+      :projects="project.subprojects"
+      :ecosystem-id="ecosystemId"
+      :parent-project="{ name: project.name, id: project.id }"
+    />
+  </div>
+</template>
+
+<script>
+import { getProjectByName } from "../apollo/queries";
+import ProjectList from "../components/ProjectList";
+
+export default {
+  name: "Project",
+  components: { ProjectList },
+  data() {
+    return {
+      project: null
+    };
+  },
+  computed: {
+    ecosystemId() {
+      return this.$route.params.ecosystemId;
+    },
+    name() {
+      return this.$route.params.name;
+    }
+  },
+  async mounted() {
+    try {
+      const response = await getProjectByName(
+        this.$apollo,
+        this.name,
+        this.ecosystemId
+      );
+      this.project = response.data.projects.entities[0];
+    } catch (error) {
+      console.error(error);
+    }
+  }
+};
+</script>

--- a/ui/tests/unit/ProjectList.spec.js
+++ b/ui/tests/unit/ProjectList.spec.js
@@ -1,0 +1,91 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import VueRouter from 'vue-router';
+import ProjectList from "@/components/ProjectList";
+import router from "@/router";
+
+Vue.use(Vuetify)
+const localVue = createLocalVue();
+localVue.use(Vuetify);
+localVue.use(VueRouter);
+
+describe("ProjectList", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return mount(ProjectList, {
+      localVue,
+      vuetify,
+      router,
+      ...options
+    });
+  };
+
+  const threeLevels = [
+    {
+      id: 1,
+      name: "parent",
+      title: "Parent",
+      ecosystem: {
+        id: 1
+      },
+      subprojects: [
+        {
+          id: 2,
+          name: "child",
+          title: "Child",
+          ecosystem: {
+            id: 1
+          },
+          subprojects: [
+            {
+              id: 3,
+              name: "grandchild",
+              title: "Grandchild",
+              ecosystem: {
+                id: 1
+              },
+              subprojects: []
+            }
+          ]
+        }
+      ]
+    }
+  ];
+
+  test("Renders all projects and subprojects", async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        projects: threeLevels,
+        ecosystemId: 1
+      }
+    });
+
+    expect(wrapper.vm.list.length).toBe(3);
+    await wrapper.vm.$nextTick();
+    const listItems = wrapper.findAll(".v-list-item");
+    expect(listItems.length).toBe(3);
+  });
+
+  test("Renders project links", async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        projects: threeLevels,
+        ecosystemId: 1
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+    const listItems = wrapper.findAll(".v-list-item");
+
+    const parent = listItems.at(0);
+    expect(parent.attributes().href).toContain("/ecosystem/1/project/parent");
+
+    const child = listItems.at(1);
+    expect(child.attributes().href).toContain("/ecosystem/1/project/child");
+
+    const grandchild = listItems.at(2);
+    expect(grandchild.attributes().href)
+      .toContain("/ecosystem/1/project/grandchild");
+  });
+});

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -63,6 +63,7 @@ exports[`ProjectsForm queries Mock query for getProjects 1`] = `
         allowoverflow="true"
         appendicon="$dropdown"
         backgroundcolor=""
+        clearable="true"
         clearicon="$clear"
         dense="true"
         errorcount="1"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -61,6 +61,7 @@ exports[`ProjectsForm queries Mock query for getProjects 1`] = `
         allowoverflow="true"
         appendicon="$dropdown"
         backgroundcolor=""
+        clearable="true"
         clearicon="$clear"
         dense="true"
         errorcount="1"


### PR DESCRIPTION
This PR adds a project overview at `/ecosystem/ecosysyemId/project/projectName`, showing the project metadata and subproject hierarchy, as requested on #54 . The view also has a link to add a new project under it, which preloads the project as a parent on the form.
An example of the `ProjectList` component, used to render the project hierarchy, can also be found on Storybook.