### PR TITLE
Remove projects from the UI

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -2,7 +2,10 @@
   <v-app>
     <v-navigation-drawer permanent app class="pa-3" color="#F5F5F5">
       <div v-for="ecosystem in ecosystems" :key="ecosystem.id">
-        <ecosystem-tree :ecosystem="ecosystem" />
+        <ecosystem-tree
+          :ecosystem="ecosystem"
+          :delete-project="deleteProject"
+        />
         <v-btn
           :to="{ name: 'project-new', params: { id: ecosystem.id } }"
           class="link"
@@ -42,6 +45,7 @@
 
 <script>
 import { getEcosystems } from "./apollo/queries";
+import { deleteProject } from "./apollo/mutations";
 import { mapGetters } from "vuex";
 import EcosystemTree from "./components/EcosystemTree";
 import SimpleDialog from "./components/SimpleDialog";
@@ -64,6 +68,25 @@ export default {
       if (response && response.data) {
         this.ecosystems = response.data.ecosystems.entities;
         this.$store.commit("setEcosystems", this.ecosystems);
+      }
+    },
+    async deleteProject(id) {
+      try {
+        await deleteProject(this.$apollo, id);
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Project deleted successfully",
+          color: "success"
+        });
+        this.getEcosystemsPage();
+      } catch (error) {
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
       }
     }
   },

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -25,21 +25,39 @@
         </transition>
       </v-container>
     </v-main>
+    <simple-dialog
+      :is-open="dialog.isOpen"
+      :title="dialog.title"
+      :text="dialog.text"
+      :action="dialog.action"
+      :warning="dialog.warning"
+      :width="dialog.width"
+    >
+    </simple-dialog>
+    <v-snackbar v-model="snackbar.isOpen" :color="snackbar.color">
+      {{ snackbar.text }}
+    </v-snackbar>
   </v-app>
 </template>
 
 <script>
 import { getEcosystems } from "./apollo/queries";
+import { mapGetters } from "vuex";
 import EcosystemTree from "./components/EcosystemTree";
+import SimpleDialog from "./components/SimpleDialog";
 
 export default {
   name: "App",
   components: {
-    EcosystemTree
+    EcosystemTree,
+    SimpleDialog
   },
   data: () => ({
     ecosystems: []
   }),
+  computed: {
+    ...mapGetters(["dialog", "snackbar"])
+  },
   methods: {
     async getEcosystemsPage(pageSize = 10, page = 1) {
       const response = await getEcosystems(this.$apollo, pageSize, page);

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -21,6 +21,16 @@ const ADD_PROJECT = gql`
   }
 `;
 
+const DELETE_PROJECT = gql`
+  mutation deleteProject($id: ID) {
+    deleteProject(id: $id) {
+      project {
+        id
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -34,4 +44,14 @@ const addProject = (apollo, data) => {
   return response;
 };
 
-export { addProject };
+const deleteProject = (apollo, id) => {
+  const response = apollo.mutate({
+    mutation: DELETE_PROJECT,
+    variables: {
+      id: id
+    }
+  });
+  return response;
+};
+
+export { addProject, deleteProject };

--- a/ui/src/components/EcosystemTree.stories.js
+++ b/ui/src/components/EcosystemTree.stories.js
@@ -5,7 +5,9 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const ecosystemTreeTemplate = '<ecosystem-tree :ecosystem="ecosystem" />';
+const ecosystemTreeTemplate = `
+  <ecosystem-tree :ecosystem="ecosystem" :delete-project="mockAction" />
+`;
 
 export const Default = () => ({
   components: { EcosystemTree },
@@ -84,5 +86,10 @@ export const Default = () => ({
         ]
       }
     };
+  },
+  methods: {
+    mockAction() {
+      return;
+    }
   }
 });

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -12,9 +12,26 @@
   >
     <template v-slot:label="{ item }">
       <div class="d-flex justify-space-between align-center hidden">
-        <router-link :to="getLink(item)">
+        <router-link :to="getLink(item)" class="router-link">
           {{ item.title }}
         </router-link>
+
+        <v-menu offset-y v-if="!item.projectSet">
+          <template v-slot:activator="{ on }">
+            <v-btn v-on="on" icon color="transparent">
+              <v-icon>mdi-dots-horizontal</v-icon>
+            </v-btn>
+          </template>
+          <v-list dense>
+            <v-list-item @click="confirmDelete(item)">
+              <v-list-item-icon class="mr-2">
+                <v-icon small color="#3f3f3f">mdi-trash-can-outline</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Delete</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+
         <v-tooltip right>
           <template v-slot:activator="{ on }">
             <v-btn
@@ -40,6 +57,10 @@ export default {
   props: {
     ecosystem: {
       type: Object,
+      required: true
+    },
+    deleteProject: {
+      type: Function,
       required: true
     }
   },
@@ -78,6 +99,15 @@ export default {
         const parent = activeRouterLink.closest(".v-treeview-node__root");
         parent.classList.add("v-treeview-node--active", "primary--text");
       }
+    },
+    confirmDelete(item) {
+      const dialog = {
+        isOpen: true,
+        title: `Delete project ${item.title}?`,
+        warning: "This will delete every project inside it.",
+        action: () => this.deleteProject(item.id)
+      };
+      this.$store.commit("setDialog", dialog);
     }
   },
   mounted() {
@@ -136,10 +166,18 @@ export default {
     color: transparent;
   }
   &:hover,
-  &:focus {
+  &:focus,
+  .v-btn:focus {
     .v-icon.v-icon {
       color: $text-color;
     }
+    .router-link {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
+}
+.v-btn--icon {
+  min-width: 36px;
 }
 </style>

--- a/ui/src/components/ProjectList.vue
+++ b/ui/src/components/ProjectList.vue
@@ -6,7 +6,6 @@
         <v-chip small pill class="ml-2">{{ list.length }}</v-chip>
       </h3>
       <v-btn
-        color="#D7DDE1"
         class="primary--text button"
         :to="{
           name: 'project-new',

--- a/ui/src/components/SimpleDialog.stories.js
+++ b/ui/src/components/SimpleDialog.stories.js
@@ -1,0 +1,81 @@
+import SimpleDialog from "./SimpleDialog.vue";
+
+export default {
+  title: "SimpleDialog",
+  excludeStories: /.*Data$/
+};
+
+const SimpleDialogTemplate = `
+  <simple-dialog
+    :is-open="isOpen"
+    :title="title"
+    :text="text"
+    :action="action"
+    :warning="warning"
+  />
+`;
+
+const SlotDialogTemplate = `
+  <simple-dialog
+    :is-open="isOpen"
+    :title="title"
+    :action="action"
+    :cancel-action="action"
+  >
+  <v-icon color="secondary" left>mdi-unicorn</v-icon>
+  <kbd>Custom content inside the slot</kbd>
+  </simple-dialog>
+`;
+
+export const Default = () => ({
+  components: { SimpleDialog },
+  template: SimpleDialogTemplate,
+  data() {
+    return {
+      isOpen: true,
+      warning: null,
+      title: "Dialog title",
+      text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        eiusmod tempor incididunt ut labore et dolore magna aliqua.`
+    };
+  },
+  methods: {
+    action() {
+      this.isOpen = false;
+    }
+  }
+});
+
+export const Warning = () => ({
+  components: { SimpleDialog },
+  template: SimpleDialogTemplate,
+  data() {
+    return {
+      isOpen: true,
+      title: "Dialog title",
+      text: null,
+      warning: "Lorem ipsum dolor sit amet"
+    };
+  },
+  methods: {
+    action() {
+      this.isOpen = false;
+    }
+  }
+});
+
+export const Slot = () => ({
+  components: { SimpleDialog },
+  template: SlotDialogTemplate,
+  data() {
+    return {
+      isOpen: true,
+      title: "Dialog title"
+    };
+  },
+  methods: {
+    action() {
+      this.isOpen = false;
+    }
+  }
+});

--- a/ui/src/components/SimpleDialog.vue
+++ b/ui/src/components/SimpleDialog.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-dialog v-model="isOpen" :max-width="width">
+    <v-card>
+      <v-card-title class="headline">{{ title }}</v-card-title>
+      <v-card-text>{{ text }}</v-card-text>
+      <v-card-text>
+        <v-alert
+          v-if="warning"
+          type="warning"
+          icon="mdi-alert-outline"
+          dense
+          text
+          border="left"
+        >
+          {{ warning }}
+        </v-alert>
+        <slot></slot>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="grey darken-2" text @click="$store.commit('clearDialog')">
+          Cancel
+        </v-btn>
+        <v-btn v-if="action" color="primary" text @click.stop="action">
+          Continue
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+<script>
+export default {
+  name: "SimpleDialog",
+  props: {
+    isOpen: {
+      type: Boolean,
+      required: true
+    },
+    title: {
+      type: String,
+      required: false
+    },
+    text: {
+      type: String,
+      required: false
+    },
+    action: {
+      type: Function,
+      required: false
+    },
+    warning: {
+      type: String,
+      required: false
+    },
+    width: {
+      type: [String, Number],
+      required: false,
+      default: 400
+    }
+  }
+};
+</script>

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -5,11 +5,42 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ecosystems: []
+    ecosystems: [],
+    dialog: {
+      isOpen: false,
+      title: null,
+      text: null,
+      action: null,
+      warning: null
+    },
+    snackbar: {
+      isOpen: false,
+      color: "success",
+      text: null
+    }
   },
   mutations: {
     setEcosystems(state, ecosystems) {
       state.ecosystems = ecosystems;
+    },
+    setDialog(state, dialog) {
+      Object.assign(state.dialog, dialog);
+    },
+    clearDialog(state) {
+      state.dialog = {
+        isOpen: false,
+        title: null
+      };
+    },
+    setSnackbar(state, snackbar) {
+      Object.assign(state.snackbar, snackbar);
+    },
+    clearSnackbar(state) {
+      state.snackbar = {
+        isOpen: false,
+        color: "success",
+        text: null
+      };
     }
   },
   getters: {
@@ -18,7 +49,9 @@ export default new Vuex.Store({
       return state.ecosystems.find(
         ecosystem => ecosystem.id.toString() === id.toString()
       );
-    }
+    },
+    dialog: state => state.dialog,
+    snackbar: state => state.snackbar
   },
   modules: {}
 });

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -8,7 +8,13 @@
       <span class="font-weight-bold">{{ project.name }}</span>
     </nav>
 
-    <h2 class="text-h5 font-weight-medium mb-9">{{ project.title }}</h2>
+    <v-row class="ma-0 mb-9 justify-space-between">
+      <h2 class="text-h5 font-weight-medium">{{ project.title }}</h2>
+      <v-btn class="primary--text button" @click="confirmDelete">
+        <v-icon dense left>mdi-trash-can-outline</v-icon>
+        Delete
+      </v-btn>
+    </v-row>
 
     <project-list
       :projects="project.subprojects"
@@ -20,6 +26,7 @@
 
 <script>
 import { getProjectByName } from "../apollo/queries";
+import { deleteProject } from "../apollo/mutations";
 import ProjectList from "../components/ProjectList";
 
 export default {
@@ -38,6 +45,37 @@ export default {
       return this.$route.params.name;
     }
   },
+  methods: {
+    confirmDelete() {
+      const dialog = {
+        isOpen: true,
+        title: `Delete project ${this.project.title}?`,
+        warning: "This will delete every project inside it.",
+        action: () => this.deleteProject(this.project.id)
+      };
+      this.$store.commit("setDialog", dialog);
+    },
+    async deleteProject(id) {
+      try {
+        await deleteProject(this.$apollo, id);
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Project deleted successfully",
+          color: "success"
+        });
+        this.$emit("updateSidebar");
+        this.$router.push("/");
+      } catch (error) {
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+    }
+  },
   async mounted() {
     try {
       const response = await getProjectByName(
@@ -52,3 +90,9 @@ export default {
   }
 };
 </script>
+<style scoped>
+.button {
+  text-transform: none;
+  letter-spacing: normal;
+}
+</style>

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -11,16 +11,6 @@ localVue.use(Vuetify);
 localVue.use(VueRouter)
 
 describe("EcosystemTree", () => {
-  const vuetify = new Vuetify();
-  const mountFunction = options => {
-    return mount(EcosystemTree, {
-      localVue,
-      vuetify,
-      router,
-      ...options
-    });
-  };
-
   const threeLevels = {
     id: 0,
     name: "root",
@@ -62,24 +52,29 @@ describe("EcosystemTree", () => {
       }
     ]
   };
-
-  test("Filters subprojects at projectSet level", () => {
-    const wrapper = mountFunction({
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return mount(EcosystemTree, {
+      localVue,
+      vuetify,
+      router,
       propsData: {
-        ecosystem: threeLevels
-      }
+        ecosystem: threeLevels,
+        deleteProject: () => {}
+      },
+      ...options
     });
+  };
+
+  test("Filters subprojects at projectSet level", async () => {
+    const wrapper = mountFunction();
 
     const children = wrapper.vm.items[0].subprojects;
     expect(children.length).toBe(1);
   });
 
-  test("Generates links", () => {
-    const wrapper = mountFunction({
-      propsData: {
-        ecosystem: threeLevels
-      }
-    });
+  test("Generates links", async () => {
+    const wrapper = mountFunction();
 
     const ecosystemLink = wrapper.vm.getLink(wrapper.vm.ecosystem);
     expect(ecosystemLink).toBe("/ecosystem/0");


### PR DESCRIPTION
Projects can be deleted from the project menu on the sidebar tree or from the project page, using the `deleteProject` GraphQL mutation. When selected, it opens a dialog to confirm the action, and after it's performed, a snackbar shows the result. The ecosystems on the sidebar are then reloaded.

A generic `SimpleDialog` is created and used for the confirmation. It can also be used in any other views or components with a custom content using the `setDialog` and `clearDialog` store mutations.

Closes #56.