### PR TITLE
Search projects by name/title

### DIFF
--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -27,6 +27,7 @@ import graphql_jwt
 
 from django.conf import settings
 from django.core.paginator import Paginator
+from django.db.models import Q
 
 from django_mysql.models import JSONField
 
@@ -230,6 +231,8 @@ class ProjectFilterType(graphene.InputObjectType):
     name = graphene.String(required=False)
     ecosystem_id = graphene.ID(required=False)
     has_parent = graphene.Boolean(required=False)
+    term = graphene.String(required=False)
+    title = graphene.String(required=False)
 
 
 class AbstractPaginatedType(graphene.ObjectType):
@@ -544,6 +547,10 @@ class BestiaryQuery(graphene.ObjectType):
             query = query.filter(title=filters['title'])
         if filters and 'ecosystem_id' in filters:
             query = query.filter(ecosystem__id=filters['ecosystem_id'])
+        if filters and 'term' in filters:
+            search_term = filters['term']
+            query = query.filter(Q(name__icontains=search_term) |
+                                 Q(title__icontains=search_term))
 
         return ProjectPaginatedType.create_paginated_result(query,
                                                             page,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -326,6 +326,19 @@ BT_PROJECTS_QUERY_FILTER = """{
     }
   }
 }"""
+BT_PROJECTS_QUERY_FILTER_TERM = """{
+  projects (
+    filters: {
+      term: "%s"
+    }
+  ){
+    entities {
+      id
+      name
+      title
+    }
+  }
+}"""
 BT_PROJECTS_QUERY_PAGINATION = """{
   projects (
     page: %d
@@ -933,6 +946,33 @@ class TestQueryProjects(django.test.TestCase):
 
         client = graphene.test.Client(schema)
         test_query = BT_PROJECTS_QUERY_FILTER % (11111111, 'Ghost-Project')
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        projects = executed['data']['projects']['entities']
+        self.assertListEqual(projects, [])
+
+    def test_filter_term_registry(self):
+        """Check whether it returns the project searched when looking for a term"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_PROJECTS_QUERY_FILTER_TERM % 'ex'
+        executed = client.execute(test_query,
+                                  context_value=self.context_value)
+
+        projects = executed['data']['projects']['entities']
+        self.assertEqual(len(projects), 1)
+
+        proj = projects[0]
+        self.assertEqual(proj['id'], str(self.proj.id))
+        self.assertEqual(proj['name'], 'Example')
+        self.assertEqual(proj['title'], 'Example title')
+
+    def test_filter_term_non_existing_registry(self):
+        """Check whether it returns an empty list when searched with a non existing term"""
+
+        client = graphene.test.Client(schema)
+        test_query = BT_PROJECTS_QUERY_FILTER_TERM % 'test'
         executed = client.execute(test_query,
                                   context_value=self.context_value)
 

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
-    <v-navigation-drawer permanent app class="pa-3" color="#F5F5F5">
+    <v-navigation-drawer permanent app class="pa-3" color="#F5F7F8">
+      <search class="mt-4" filled @search="search" ref="search" />
       <div v-for="ecosystem in ecosystems" :key="ecosystem.id">
         <ecosystem-tree
           :ecosystem="ecosystem"
@@ -48,12 +49,14 @@ import { getEcosystems } from "./apollo/queries";
 import { deleteProject } from "./apollo/mutations";
 import { mapGetters } from "vuex";
 import EcosystemTree from "./components/EcosystemTree";
+import Search from "./components/Search";
 import SimpleDialog from "./components/SimpleDialog";
 
 export default {
   name: "App",
   components: {
     EcosystemTree,
+    Search,
     SimpleDialog
   },
   data: () => ({
@@ -88,6 +91,10 @@ export default {
           color: "error"
         });
       }
+    },
+    search(query) {
+      this.$router.push({ name: "search", query });
+      this.$refs.search.clearInput();
     }
   },
   created() {

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -11,6 +11,12 @@ const projectFragment = gql`
     }
     parentProject {
       name
+      parentProject {
+        name
+        parentProject {
+          name
+        }
+      }
     }
   }
 `;
@@ -44,8 +50,8 @@ const GET_ECOSYSTEMS = gql`
   ${projectFragment}
 `;
 
-const GET_PROJECTS = gql`
-  query GetProjects($pageSize: Int, $page: Int, $filters: ProjectFilterType) {
+const GET_BASIC_PROJECT_INFO = gql`
+  query GetBasicInfo($pageSize: Int, $page: Int, $filters: ProjectFilterType) {
     projects(pageSize: $pageSize, page: $page, filters: $filters) {
       entities {
         id
@@ -53,6 +59,30 @@ const GET_PROJECTS = gql`
       }
     }
   }
+`;
+
+const GET_PROJECTS = gql`
+  query GetProjects($pageSize: Int, $page: Int, $filters: ProjectFilterType) {
+    projects(pageSize: $pageSize, page: $page, filters: $filters) {
+      entities {
+        ...projectFields
+        subprojects {
+          ...projectFields
+          subprojects {
+            ...projectFields
+            subprojects {
+              ...projectFields
+            }
+          }
+        }
+      }
+      pageInfo {
+        page
+        numPages
+      }
+    }
+  }
+  ${projectFragment}
 `;
 
 const GET_PROJECT_BY_NAME = gql`
@@ -87,6 +117,18 @@ const getEcosystems = (apollo, pageSize, page) => {
   return response;
 };
 
+const GetBasicProjectInfo = (apollo, pageSize, page, filters) => {
+  const response = apollo.query({
+    query: GET_BASIC_PROJECT_INFO,
+    variables: {
+      pageSize,
+      page,
+      filters
+    }
+  });
+  return response;
+};
+
 const getProjects = (apollo, pageSize, page, filters) => {
   const response = apollo.query({
     query: GET_PROJECTS,
@@ -113,4 +155,4 @@ const getProjectByName = (apollo, name, ecosystemId) => {
   return response;
 };
 
-export { getEcosystems, getProjects, getProjectByName };
+export { getEcosystems, GetBasicProjectInfo, getProjects, getProjectByName };

--- a/ui/src/components/ProjectEntry.stories.js
+++ b/ui/src/components/ProjectEntry.stories.js
@@ -1,0 +1,24 @@
+import ProjectEntry from "./ProjectEntry.vue";
+
+export default {
+  title: "ProjectEntry",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <v-list two-line>
+    <project-entry :title='title' :route='route' :path='path' />
+  </v-list>
+`;
+
+export const Default = () => ({
+  components: { ProjectEntry },
+  template: template,
+  data() {
+    return {
+      title: "Project Title",
+      route: "/ecosystem/0/project/name",
+      path: "ecosystem / name"
+    };
+  }
+});

--- a/ui/src/components/ProjectEntry.vue
+++ b/ui/src/components/ProjectEntry.vue
@@ -1,0 +1,50 @@
+<template>
+  <router-link :to="route" custom v-slot="{ href, route, navigate }">
+    <v-list-item :href="href" @click="navigate">
+      <v-list-item-content>
+        <v-list-item-title v-html="highlightName(path)" />
+        <v-list-item-subtitle>{{ title }}</v-list-item-subtitle>
+      </v-list-item-content>
+    </v-list-item>
+  </router-link>
+</template>
+
+<script>
+export default {
+  name: "ProjectEntry",
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    path: {
+      type: String,
+      required: true
+    },
+    route: {
+      type: String,
+      required: true
+    }
+  },
+  methods: {
+    highlightName(route) {
+      let names = route.split("/");
+      if (names.length === 1) {
+        return `<span>${route}</span>`;
+      } else {
+        const last = names.pop();
+        return `${[...names].join(" / ")} / <span>${last}</span>`;
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+::v-deep .v-list-item__title span {
+  font-weight: 500;
+}
+.v-list-item--link::before {
+  background-color: #003756;
+}
+</style>

--- a/ui/src/components/ProjectList.vue
+++ b/ui/src/components/ProjectList.vue
@@ -6,7 +6,7 @@
         <v-chip small pill class="ml-2">{{ list.length }}</v-chip>
       </h3>
       <v-btn
-        class="primary--text button"
+        class="primary--text button--lowercase"
         :to="{
           name: 'project-new',
           params: {
@@ -20,27 +20,23 @@
       </v-btn>
     </div>
     <v-list two-line>
-      <router-link
+      <project-entry
         v-for="project in list"
         :key="project.id"
-        :to="project.route"
-        custom
-        v-slot="{ href, route, navigate }"
-      >
-        <v-list-item :href="href" @click="navigate">
-          <v-list-item-content>
-            <v-list-item-title v-html="highlightName(project.path)" />
-            <v-list-item-subtitle>{{ project.title }}</v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-      </router-link>
+        :title="project.title"
+        :route="project.route"
+        :path="project.path"
+      />
     </v-list>
   </section>
 </template>
 
 <script>
+import ProjectEntry from "./ProjectEntry";
+
 export default {
   name: "ProjectList",
+  components: { ProjectEntry },
   props: {
     projects: {
       type: Array,
@@ -103,7 +99,7 @@ export default {
 ::v-deep .v-list-item__title span {
   font-weight: 500;
 }
-.button {
+.button--lowercase {
   text-transform: none;
   letter-spacing: normal;
 }

--- a/ui/src/components/Search.stories.js
+++ b/ui/src/components/Search.stories.js
@@ -1,0 +1,61 @@
+import Search from "./Search.vue";
+
+export default {
+  title: "Search",
+  excludeStories: /.*Data$/
+};
+
+const searchTemplate = `
+  <v-col cols="5">
+    <search
+      :valid-filters='validFilters'
+      :filter-selector='filterSelector'
+      :filled='filled'
+    />
+  </v-col>
+`;
+
+export const Default = () => ({
+  components: { Search },
+  template: searchTemplate,
+  data() {
+    return {
+      filterSelector: false,
+      validFilters: [],
+      filled: false
+    };
+  }
+});
+
+export const Filled = () => ({
+  components: { Search },
+  template: searchTemplate,
+  data() {
+    return {
+      filterSelector: false,
+      validFilters: [],
+      filled: true
+    };
+  }
+});
+
+export const filterSelector = () => ({
+  components: { Search },
+  template: searchTemplate,
+  data() {
+    return {
+      filterSelector: true,
+      validFilters: [
+        {
+          filter: "filter1",
+          type: "string"
+        },
+        {
+          filter: "filter2",
+          type: "string"
+        }
+      ],
+      filled: false
+    };
+  }
+});

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -1,0 +1,194 @@
+<template>
+  <v-text-field
+    v-model.trim="inputValue"
+    label="Search projects"
+    prepend-inner-icon="mdi-magnify"
+    clear-icon="mdi-close-circle-outline"
+    ref="searchInput"
+    :error-messages="errorMessage"
+    :outlined="!filled"
+    :solo="filled"
+    :flat="filled"
+    clearable
+    dense
+    single-line
+    @click:prepend-inner="search"
+    @keyup.enter="search"
+    @click:clear="clearInput"
+  >
+    <template v-slot:append-outer v-if="filterSelector">
+      <v-menu offset-y>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            class="btn--focusable text-body-1"
+            outlined
+            height="40"
+            v-bind="attrs"
+            v-on="on"
+          >
+            Filters
+            <v-icon small right>mdi-chevron-down</v-icon>
+          </v-btn>
+        </template>
+        <v-list dense class="mt-1">
+          <v-list-item
+            v-for="(item, i) in validFilters.filter(o => o.filter !== 'term')"
+            :key="i"
+            @click="setFilter(item)"
+          >
+            <v-list-item-title>
+              {{ item.filter }}
+            </v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </template>
+  </v-text-field>
+</template>
+
+<script>
+export default {
+  name: "Search",
+  props: {
+    filled: {
+      type: Boolean,
+      required: false
+    },
+    setValue: {
+      type: String,
+      required: false
+    },
+    filterSelector: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    validFilters: {
+      type: Array,
+      required: false,
+      default: () => [
+        {
+          filter: "term",
+          type: "string"
+        },
+        {
+          filter: "name",
+          type: "string"
+        },
+        {
+          filter: "title",
+          type: "string"
+        }
+      ]
+    }
+  },
+  data() {
+    return {
+      inputValue: this.setValue,
+      filters: {},
+      errorMessage: null
+    };
+  },
+  methods: {
+    async search() {
+      await this.parseFilters();
+      if (this.errorMessage) return;
+      this.$refs.searchInput.focus(false);
+      this.$emit("search", this.filters);
+    },
+    parseFilters() {
+      const terms = [];
+      this.filters = {};
+      this.errorMessage = null;
+
+      if (!this.inputValue) return this.filters;
+
+      const input = this.parseQuotes(this.inputValue);
+      input.split(" ").forEach(value => {
+        if (value.includes(":")) {
+          const [filter, text] = value.split(":");
+          if (!this.validFilters.find(vfilter => vfilter.filter === filter)) {
+            this.errorMessage = `Invalid filter "${filter}"`;
+          } else {
+            this.filters[filter] = text;
+          }
+        } else if (value.trim()) {
+          terms.push(value.replace(/"/g, ""));
+        }
+      });
+      if (terms.length !== 0) {
+        this.filters.term = terms.join(" ").trim();
+      }
+    },
+    parseQuotes(input) {
+      const regexp = /(\w*):"(.*?)"/gm;
+      const matches = [...input.matchAll(regexp)];
+
+      matches.forEach(match => {
+        const filter = match[1];
+        const value = match[2];
+        if (this.validFilters.find(vfilter => vfilter.filter === filter)) {
+          this.filters[filter] = value;
+          input = input.replace(match[0], "");
+        } else {
+          this.errorMessage = `Invalid filter "${filter}"`;
+        }
+      });
+
+      return input;
+    },
+    clearInput() {
+      this.inputValue = null;
+      this.filters = {};
+      this.errorMessage = null;
+    },
+    setFilter(item) {
+      this.inputValue = this.inputValue || "";
+      this.inputValue += ` ${item.filter}:"search value" `;
+    }
+  },
+  watch: {
+    setValue(value) {
+      this.inputValue = value;
+    }
+  },
+  mounted() {
+    if (this.inputValue) {
+      this.search();
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+.v-text-field--enclosed.v-input--dense:not(.v-text-field--solo).v-text-field--outlined
+  ::v-deep
+  .v-input__append-outer {
+  margin-top: 0;
+
+  .v-btn__content {
+    text-transform: none;
+    letter-spacing: normal;
+  }
+}
+
+.v-text-field--solo-flat {
+  font-size: 0.875rem;
+
+  ::v-deep .v-label {
+    font-size: 0.875rem;
+  }
+
+  ::v-deep .v-icon {
+    font-size: 1.1rem;
+  }
+
+  &.v-text-field--enclosed:not(.v-text-field--rounded)
+    > ::v-deep
+    .v-input__control
+    > .v-input__slot {
+    padding: 0 4px;
+  }
+}
+</style>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -14,6 +14,11 @@ const router = new Router({
       path: "/ecosystem/:ecosystemId/project/:name",
       component: () => import("../views/Project"),
       props: true
+    },
+    {
+      name: "search",
+      path: "/search",
+      component: () => import("../views/SearchResults")
     }
   ]
 });

--- a/ui/src/styles/_buttons.scss
+++ b/ui/src/styles/_buttons.scss
@@ -1,0 +1,30 @@
+// Outlined button with thick border on focus
+.v-btn--outlined.btn--focusable {
+  border-color: rgba(0, 0, 0, 0.42);
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border: 0;
+  }
+
+  &:hover {
+    border-color: rgba(0, 0, 0, 0.87);
+    &::before {
+      opacity: 0;
+    }
+  }
+  &:focus {
+    border-color: #003756;
+    &::before {
+      opacity: 0;
+    }
+    &::after {
+      border: thin solid #003756;
+    }
+  }
+}

--- a/ui/src/styles/_buttons.scss
+++ b/ui/src/styles/_buttons.scss
@@ -28,3 +28,15 @@
     }
   }
 }
+
+// Pagination buttons
+::v-deep .theme--light.v-pagination .v-pagination__item,
+::v-deep .theme--light.v-pagination .v-pagination__navigation {
+  box-shadow: none;
+  border: thin solid rgba(0, 0, 0, 0.42);
+
+  &--disabled {
+    color: rgba(0, 0, 0, 0.42);
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+}

--- a/ui/src/views/NewProject.vue
+++ b/ui/src/views/NewProject.vue
@@ -19,7 +19,7 @@
 
 <script>
 import ProjectForm from "../components/ProjectForm";
-import { getProjects } from "../apollo/queries";
+import { GetBasicProjectInfo } from "../apollo/queries";
 import { addProject } from "../apollo/mutations";
 
 export default {
@@ -38,7 +38,7 @@ export default {
   },
   methods: {
     async getProjects(ecosystem, pageSize = 50, page = 1) {
-      const response = await getProjects(this.$apollo, pageSize, page, {
+      const response = await GetBasicProjectInfo(this.$apollo, pageSize, page, {
         ecosystemId: ecosystem
       });
       if (response) {

--- a/ui/src/views/SearchResults.vue
+++ b/ui/src/views/SearchResults.vue
@@ -1,0 +1,111 @@
+<template>
+  <section class="pa-5">
+    <h2 class="text-h5 font-weight-medium mb-9">
+      Search
+    </h2>
+    <search :set-value="setValue" @search="search" filter-selector />
+    <h3 class="text-body-1 font-weight-bold d-flex align-center mt-3 mb-1">
+      Projects
+      <v-chip small class="ml-3" color="#F5F7F8">{{ results.length }}</v-chip>
+    </h3>
+    <v-list two-line>
+      <project-entry
+        v-for="project in results"
+        :key="project.id"
+        :title="project.title"
+        :route="project.route"
+        :path="project.path"
+      />
+    </v-list>
+    <v-pagination
+      v-if="results.length > 0"
+      v-model="page"
+      class="my-4 pagination"
+      :length="totalPages"
+      @input="queryProjects($event)"
+    ></v-pagination>
+  </section>
+</template>
+
+<script>
+import ProjectEntry from "../components/ProjectEntry";
+import Search from "../components/Search";
+import { getProjects } from "../apollo/queries";
+
+export default {
+  name: "SearchResults",
+  components: { ProjectEntry, Search },
+  data() {
+    return {
+      filters: {},
+      results: [],
+      page: 1,
+      totalPages: 1
+    };
+  },
+  computed: {
+    setValue() {
+      return Object.entries(this.query)
+        .map(([key, value]) => {
+          value = value.replace(/"/g, "");
+          if (key === "term") {
+            return value;
+          } else {
+            return `${key}:"${value}"`;
+          }
+        })
+        .toString()
+        .replace(",", " ");
+    },
+    query() {
+      return this.$route.query;
+    }
+  },
+  methods: {
+    search(filters) {
+      this.filters = filters;
+      this.queryProjects(1, filters);
+      this.$router.replace({ name: "search", query: filters }).catch(() => {});
+    },
+    async queryProjects(page = this.page, filters = this.filters) {
+      const response = await getProjects(this.$apollo, 20, page, filters);
+      if (response) {
+        this.results = response.data.projects.entities;
+        this.results.forEach(res => {
+          const path = this.getPath(res);
+          const route = `/ecosystem/${res.ecosystem.id}/project/${res.name}`;
+          Object.assign(res, { path, route });
+        });
+        this.page = response.data.projects.pageInfo.page;
+        this.totalPages = response.data.projects.pageInfo.numPages;
+      }
+    },
+    getPath(project) {
+      const path = [project.name];
+
+      function findParents(parent) {
+        if (parent) {
+          path.push(parent.name);
+          findParents(parent.parentProject);
+        } else {
+          path.push(project.ecosystem.name);
+        }
+      }
+
+      findParents(project.parentProject);
+
+      return path
+        .reverse()
+        .toString()
+        .replace(/,/g, " / ");
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+.v-list-item:not(:last-child) {
+  border-bottom: thin solid rgba(0, 0, 0, 0.12);
+}
+</style>

--- a/ui/tests/unit/Search.spec.js
+++ b/ui/tests/unit/Search.spec.js
@@ -1,0 +1,74 @@
+import { mount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import Search from "@/components/Search";
+
+Vue.use(Vuetify);
+
+describe("Search", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return mount(Search, {
+      vuetify,
+      ...options
+    });
+  };
+
+  test.each([
+    ["test", { term: "test" }],
+    [`"test"`, { term: "test" }],
+    ["term:test", { term: "test" }],
+    [`term:"test"`, { term: "test" }],
+    ["test name:value", { term: "test", name: "value" }]
+  ])("Gets filters from input value", async (value, expected) => {
+    const wrapper = mountFunction({
+      data: () => ({ inputValue: value })
+    });
+
+    const button = wrapper.find("button.mdi-magnify");
+    await button.trigger("click");
+
+    expect(wrapper.vm.filters).toMatchObject(expected);
+  });
+
+  test("Shows selected filter on the search box", async () => {
+      const wrapper = mountFunction({
+        propsData: {
+          filterSelector: true,
+          validFilters: [
+            { filter: "testFilter" }
+          ]
+        }
+      });
+
+      const el = document.createElement("div");
+      el.setAttribute("data-app", true);
+      document.body.appendChild(el);
+
+      const button = wrapper.find(".btn--focusable");
+      await button.trigger("click");
+      const filter = wrapper.find(".v-list-item");
+      await filter.trigger("click");
+
+      expect(wrapper.vm.inputValue).toContain(`testFilter:"search value"`);
+    }
+  );
+
+  test("Validates filters", async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        validFilters: [
+          { filter: "testFilter" }
+        ]
+      },
+      data: () => ({ inputValue: "invalidFilter:test" })
+    });
+
+    const button = wrapper.find("button.mdi-magnify");
+    await button.trigger("click");
+    const errorMessage = wrapper.find(".v-messages__message");
+
+    expect(errorMessage.exists()).toBe(true);
+    expect(errorMessage.text()).toContain("Invalid filter");
+  })
+})

--- a/ui/tests/unit/SearchResults.spec.js
+++ b/ui/tests/unit/SearchResults.spec.js
@@ -1,0 +1,55 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import SearchResults from "@/views/SearchResults";
+
+Vue.use(Vuetify);
+
+describe("SearchResults", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return shallowMount(SearchResults, {
+      vuetify,
+      ...options
+    });
+  };
+
+  test("Gets filters from route", () => {
+    const wrapper = mountFunction({
+      mocks: {
+        $route: {
+          query: {
+            filter1: "value",
+            filter2: "filter 2 value"
+          }
+        }
+      }
+    });
+
+    expect(wrapper.vm.setValue).toBe(`filter1:"value" filter2:"filter 2 value"`)
+  });
+
+  test("Gets project path from parents", () => {
+    const wrapper = mountFunction({
+      mocks: {
+        $route: {
+          query: {}
+        }
+      },
+    });
+    const project = {
+      name: "sub-subproject",
+      ecosystem: { name: "ecosystem"},
+      parentProject: {
+        name: "subproject",
+        parentProject: {
+          name: "project",
+          parentProject: null
+        }
+      }
+    };
+    const path = wrapper.vm.getPath(project);
+
+    expect(path).toBe("ecosystem / project / subproject / sub-subproject");
+  })
+});


### PR DESCRIPTION
Users can search for a list of projects filtering by name, title or term (text contained in the name or title, similar to the SortingHat filter) at the `/search` route using query params, for example `/search?term=example`.
The view shows a search box with filters (the `Search` component) and a list of results that link to each project (`ProjectEntry`). 
They can also search from the box placed on the sidebar, which redirects to the search route.
The search syntax is `filter:value` or `filter:"value"` and any single word without a filter is considered a term.

The `name` and `title` filters already existed in the schema, but the `term` filter had to be added.

Closes #58.