### PR TITLE
[ui] Edit project data

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -31,6 +31,28 @@ const DELETE_PROJECT = gql`
   }
 `;
 
+const MOVE_PROJECT = gql`
+  mutation moveProject($fromProjectId: ID, $toProjectId: ID) {
+    moveProject(fromProjectId: $fromProjectId, toProjectId: $toProjectId) {
+      project {
+        id
+        name
+      }
+    }
+  }
+`;
+
+const UPDATE_PROJECT = gql`
+  mutation updateProject($data: ProjectInputType, $id: ID) {
+    updateProject(data: $data, id: $id) {
+      project {
+        id
+        name
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -54,4 +76,26 @@ const deleteProject = (apollo, id) => {
   return response;
 };
 
-export { addProject, deleteProject };
+const moveProject = (apollo, fromProjectId, toProjectId) => {
+  const response = apollo.mutate({
+    mutation: MOVE_PROJECT,
+    variables: {
+      fromProjectId: fromProjectId,
+      toProjectId: toProjectId
+    }
+  });
+  return response;
+};
+
+const updateProject = (apollo, data, id) => {
+  const response = apollo.mutate({
+    mutation: UPDATE_PROJECT,
+    variables: {
+      data: data,
+      id: id
+    }
+  });
+  return response;
+};
+
+export { addProject, deleteProject, moveProject, updateProject };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -10,10 +10,13 @@ const projectFragment = gql`
       name
     }
     parentProject {
+      id
       name
       parentProject {
+        id
         name
         parentProject {
+          id
           name
         }
       }
@@ -56,6 +59,7 @@ const GET_BASIC_PROJECT_INFO = gql`
       entities {
         id
         title
+        name
       }
     }
   }
@@ -136,7 +140,8 @@ const getProjects = (apollo, pageSize, page, filters) => {
       pageSize,
       page,
       filters
-    }
+    },
+    fetchPolicy: "no-cache"
   });
   return response;
 };

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -23,6 +23,20 @@
             </v-btn>
           </template>
           <v-list dense>
+            <v-list-item
+              :to="{
+                name: 'project-edit',
+                params: {
+                  id: item.ecosystem.id,
+                  name: item.name
+                }
+              }"
+            >
+              <v-list-item-icon class="mr-2">
+                <v-icon small color="#3f3f3f">mdi-pencil-outline</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Edit</v-list-item-title>
+            </v-list-item>
             <v-list-item @click="confirmDelete(item)">
               <v-list-item-icon class="mr-2">
                 <v-icon small color="#3f3f3f">mdi-trash-can-outline</v-icon>

--- a/ui/src/components/ProjectForm.stories.js
+++ b/ui/src/components/ProjectForm.stories.js
@@ -9,7 +9,7 @@ const ProjectFormTemplate = `
   <project-form
     :ecosystemId="1"
     :get-projects="getProjects"
-    :add-project="addProject"
+    :save-function="addProject"
   />
 `;
 

--- a/ui/src/components/ProjectForm.vue
+++ b/ui/src/components/ProjectForm.vue
@@ -3,7 +3,7 @@
     <v-row>
       <v-col cols="4">
         <v-text-field
-          v-model="title"
+          v-model="form.title"
           label="Project title"
           :rules="validations.required"
           outlined
@@ -15,7 +15,7 @@
     <v-row>
       <v-col cols="4">
         <v-text-field
-          v-model="name"
+          v-model="form.name"
           label="Project name"
           :rules="validations.required"
           outlined
@@ -27,7 +27,7 @@
     <v-row>
       <v-col cols="4">
         <v-autocomplete
-          v-model="parentId"
+          v-model="form.parentId"
           :items="projects"
           label="Parent project (optional)"
           item-text="title"
@@ -71,9 +71,17 @@ export default {
       type: Function,
       required: true
     },
-    addProject: {
+    saveFunction: {
       type: Function,
       required: true
+    },
+    name: {
+      type: String,
+      required: false
+    },
+    title: {
+      type: String,
+      required: false
     },
     parent: {
       type: Object,
@@ -83,9 +91,11 @@ export default {
   },
   data() {
     return {
-      name: null,
-      title: null,
-      parentId: null,
+      form: {
+        name: this.name,
+        title: this.title,
+        parentId: null
+      },
       touchedName: false,
       projects: [],
       validations: {
@@ -95,8 +105,8 @@ export default {
   },
   methods: {
     suggestName(value) {
-      if (value && !this.touchedName) {
-        this.name = value
+      if (value && !this.name && !this.touchedName) {
+        this.form.name = value
           .trim()
           .replace(/\s+/g, "-")
           .toLowerCase();
@@ -113,12 +123,12 @@ export default {
         return;
       }
       const data = {
-        name: this.name.trim(),
-        title: this.title,
-        parentId: this.parentId ? Number(this.parentId) : null,
+        name: this.form.name.trim(),
+        title: this.form.title,
+        parentId: this.form.parentId ? Number(this.form.parentId) : null,
         ecosystemId: this.ecosystemId
       };
-      const response = await this.addProject(data);
+      const response = await this.saveFunction(data);
       if (response) {
         const projectName = response.name;
         this.$router.push({
@@ -127,10 +137,19 @@ export default {
       }
     }
   },
+  watch: {
+    title(value) {
+      this.form.title = value;
+    },
+    parent(value) {
+      this.loadParentProjects();
+      this.form.parentId = value.id;
+    }
+  },
   created() {
     if (this.parent) {
       this.loadParentProjects();
-      this.parentId = this.parent.id;
+      this.form.parentId = this.parent.id;
     }
   }
 };

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -16,6 +16,12 @@ const router = new Router({
       props: true
     },
     {
+      name: "project-edit",
+      path: "/ecosystem/:id/project/:name/edit",
+      component: () => import("../views/EditProject"),
+      props: true
+    },
+    {
       name: "search",
       path: "/search",
       component: () => import("../views/SearchResults")

--- a/ui/src/views/EditProject.vue
+++ b/ui/src/views/EditProject.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="pa-5">
+    <h2 v-if="project" class="text-body-1 font-weight-light mb-9">
+      Bestiary / {{ project.ecosystem.name }} /
+      <span v-if="project.parentProject">
+        {{ project.parentProject.name }} /
+      </span>
+      {{ name }} /
+      <span class="font-weight-bold">Edit project</span>
+    </h2>
+    <project-form
+      v-if="showForm"
+      :ecosystemId="ecosystemId"
+      :get-projects="getParentProjects"
+      :save-function="updateProject"
+      :name="name"
+      :title="project.title"
+      :parent="project.parentProject"
+    />
+
+    <v-alert v-if="error" text outlined type="error" width="32%" class="mt-9">
+      {{ error }}
+    </v-alert>
+  </div>
+</template>
+
+<script>
+import ProjectForm from "../components/ProjectForm";
+import { getProjects, getProjectByName } from "../apollo/queries";
+import { moveProject, updateProject } from "../apollo/mutations";
+
+export default {
+  name: "EditProject",
+  components: { ProjectForm },
+  data() {
+    return {
+      error: null,
+      showForm: false,
+      project: null
+    };
+  },
+  computed: {
+    ecosystemId() {
+      return this.$route.params.id ? Number(this.$route.params.id) : null;
+    },
+    name() {
+      return this.$route.params.name;
+    }
+  },
+  methods: {
+    async getProjectMetadata() {
+      try {
+        const response = await getProjectByName(
+          this.$apollo,
+          this.name,
+          this.ecosystemId
+        );
+        if (response && response.data.projects.entities[0]) {
+          this.project = response.data.projects.entities[0];
+          this.showForm = true;
+        } else {
+          this.error = "Project not found";
+        }
+      } catch (error) {
+        this.error = error;
+      }
+    },
+    async getParentProjects(ecosystem, pageSize = 50, page = 1) {
+      const response = await getProjects(this.$apollo, pageSize, page, {
+        ecosystemId: ecosystem
+      });
+      if (response && !response.errors) {
+        return this.validateParentProjects(response.data.projects.entities);
+      }
+    },
+    async updateProject(formData) {
+      const data = {
+        name: formData.name,
+        title: formData.title,
+        parentProject: formData.parentId
+      };
+      try {
+        const response = await updateProject(
+          this.$apollo,
+          data,
+          this.project.id
+        );
+        if (response && !response.errors) {
+          if (
+            formData.parentId &&
+            formData.parentId.toString() !==
+              (this.project.parentProject
+                ? this.project.parentProject.id.toString()
+                : null)
+          ) {
+            try {
+              await this.moveProject(this.project.id, formData.parentId);
+            } catch (error) {
+              this.error = error;
+              return;
+            }
+          }
+          this.$emit("updateSidebar");
+          return response.data.updateProject.project;
+        }
+      } catch (error) {
+        this.error = error;
+      }
+    },
+    async moveProject(from, to) {
+      const response = await moveProject(this.$apollo, from, to);
+      return response;
+    },
+    validateParentProjects(projects) {
+      return projects.filter(project => {
+        if (project.name === this.name) {
+          return false;
+        } else if (
+          this.project.parentProject &&
+          this.getRoot(this.project.parentProject).id !==
+            this.getRoot(project).id
+        ) {
+          // If the project is not a root one, when the parent comes from a
+          // different root project.
+          return false;
+        } else if (this.isDescendant(project, this.project)) {
+          return false;
+        }
+        return true;
+      });
+    },
+    getRoot(project) {
+      const parent = project ? project.parentProject : null;
+      if (parent) {
+        project = this.getRoot(parent);
+      }
+      return project;
+    },
+    isDescendant(project, fromProject) {
+      const queue = [fromProject];
+      while (queue.length > 0) {
+        const current = queue.pop(0);
+        if (current.subprojects) {
+          for (let subproject of current.subprojects) {
+            if (subproject.id === project.id) {
+              return true;
+            }
+            queue.push(subproject);
+          }
+        }
+      }
+    }
+  },
+  mounted() {
+    this.getProjectMetadata();
+  }
+};
+</script>

--- a/ui/src/views/NewProject.vue
+++ b/ui/src/views/NewProject.vue
@@ -5,7 +5,7 @@
       v-if="isEcosystem"
       :ecosystemId="ecosystemId"
       :get-projects="getProjects"
-      :add-project="addProject"
+      :save-function="addProject"
       :parent="parent"
     />
     <v-alert v-else text outlined type="error" width="50%">

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -3,10 +3,25 @@
     <breadcrumbs :items="breadcrumbs" />
     <v-row class="ma-0 mb-9 justify-space-between">
       <h2 class="text-h5 font-weight-medium">{{ project.title }}</h2>
-      <v-btn class="primary--text button" @click="confirmDelete">
-        <v-icon dense left>mdi-trash-can-outline</v-icon>
-        Delete
-      </v-btn>
+      <div>
+        <v-btn
+          class="primary--text button mr-6"
+          :to="{
+            name: 'project-edit',
+            params: {
+              id: ecosystemId,
+              name: name
+            }
+          }"
+        >
+          <v-icon dense left>mdi-pencil-outline</v-icon>
+          Edit
+        </v-btn>
+        <v-btn class="primary--text button" @click="confirmDelete">
+          <v-icon dense left>mdi-trash-can-outline</v-icon>
+          Delete
+        </v-btn>
+      </div>
     </v-row>
 
     <project-list

--- a/ui/tests/unit/EditProject.spec.js
+++ b/ui/tests/unit/EditProject.spec.js
@@ -1,0 +1,110 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import EditProject from "@/views/EditProject";
+
+Vue.use(Vuetify);
+
+describe("EditProject", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return shallowMount(EditProject, {
+      vuetify,
+      ...options
+    });
+  };
+  const parentProjects = [
+    {
+      id: 1,
+      name: "root1",
+      subprojects: [
+        {
+          id: 3,
+          name: "child",
+          parentProject: {
+            id: 1,
+            name: "root1"
+          }
+        }
+      ]
+    },
+    {
+      id: 2,
+      name: "root2"
+    },
+    {
+      id: 3,
+      name: "child",
+      parentProject: {
+        id: 1,
+        name: "root1"
+      }
+    }
+  ];
+
+  test("Filters out the project's descendants", async () => {
+    const wrapper = mountFunction({
+      mocks: {
+        $route: {
+          params: {
+            id: 1,
+            name: "root1"
+          }
+        }
+      },
+      data() {
+        return {
+          project: {
+            id: 1,
+            name: "root1",
+            subprojects: [
+              {
+                id: 3,
+                name: "child",
+                parentProject: {
+                  id: 1,
+                  name: "root1"
+                }
+              }
+            ],
+            ecosystem: { name: "ecosystem" }
+          }
+        };
+      }
+    });
+
+    const validParents = wrapper.vm.validateParentProjects(parentProjects);
+    expect(validParents.length).toBe(1);
+    expect(validParents[0].name).toBe("root2");
+  });
+
+  test("Filters out other root projects for children", async () => {
+    const wrapper = mountFunction({
+      mocks: {
+        $route: {
+          params: {
+            id: 3,
+            name: "child"
+          }
+        }
+      },
+      data() {
+        return {
+          project: {
+            id: 3,
+            name: "child",
+            parentProject: {
+              id: 1,
+              name: "root1"
+            },
+            ecosystem: { name: "ecosystem" }
+          }
+        };
+      }
+    });
+
+    const validParents = wrapper.vm.validateParentProjects(parentProjects);
+    expect(validParents.length).toBe(1);
+    expect(validParents[0].name).toBe("root1");
+  });
+});

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProjectsForm queries Mock query for getProjects 1`] = `
+exports[`ProjectsForm mutations Mock mutation for addProject 1`] = `
 <v-form-stub>
   <v-row-stub
     tag="div"
@@ -85,6 +85,144 @@ exports[`ProjectsForm queries Mock query for getProjects 1`] = `
         rules=""
         successmessages=""
         type="text"
+        valuecomparator="function deepEqual(a, b) {
+  if (a === b) return true;
+
+  if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+    // If the values are Date, compare them as timestamps
+    return false;
+  }
+
+  if (a !== Object(a) || b !== Object(b)) {
+    // If the values aren't objects, they were already checked for equality
+    return false;
+  }
+
+  var props = Object.keys(a);
+
+  if (props.length !== Object.keys(b).length) {
+    // Different number of props, don't bother to check
+    return false;
+  }
+
+  return props.every(function (p) {
+    return deepEqual(a[p], b[p]);
+  });
+}"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      class="d-flex justify-end"
+      cols="4"
+      tag="div"
+    >
+      <v-btn-stub
+        activeclass=""
+        color="primary"
+        depressed="true"
+        tag="button"
+        type="button"
+      >
+        
+        Save
+      
+      </v-btn-stub>
+    </v-col-stub>
+  </v-row-stub>
+</v-form-stub>
+`;
+
+exports[`ProjectsForm mutations Mock mutation for updateProject 1`] = `
+<v-form-stub>
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Project title"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="value => !!value || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="Test Title"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Project name"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="value => !!value || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="test"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-autocomplete-stub
+        allowoverflow="true"
+        appendicon="$dropdown"
+        backgroundcolor=""
+        clearable="true"
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        filter="function _default(item, queryText, itemText) {
+        return itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1;
+      }"
+        itemcolor="primary"
+        itemdisabled="disabled"
+        items=""
+        itemtext="title"
+        itemvalue="id"
+        label="Parent project (optional)"
+        loaderheight="2"
+        menuprops="[object Object]"
+        messages=""
+        nodatatext="$vuetify.noDataText"
+        outlined="true"
+        rules=""
+        successmessages=""
+        type="text"
+        value="2"
         valuecomparator="function deepEqual(a, b) {
   if (a === b) return true;
 

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -6,7 +6,20 @@ import ProjectForm from "@/components/ProjectForm";
 
 Vue.use(Vuetify);
 
-describe("ProjectsForm queries", () => {
+describe("ProjectsForm mutations", () => {
+  const mountFunction = options => {
+    return shallowMount(ProjectForm, {
+      Vue,
+      Vuetify,
+      propsData: {
+        ecosystemId: 1,
+        getProjects: () => {},
+        saveFunction: () => {}
+      },
+      ...options
+    });
+  };
+
   const addProjectResponse = {
     data: {
       addProject: {
@@ -20,34 +33,83 @@ describe("ProjectsForm queries", () => {
     }
   };
 
-  test("Mock query for getProjects", async () => {
+  const updateProjectResponse = {
+    data: {
+      updateProject: {
+        project: {
+          id: "39",
+          name: "test",
+          __typename: "ProjectType"
+        },
+        __typename: "UpdateProject"
+      }
+    }
+  };
+
+  test("Mock mutation for addProject", async () => {
     const mutate = jest.fn(() => Promise.resolve(addProjectResponse));
-    const wrapper = shallowMount(ProjectForm, {
-      Vue,
+    const wrapper = mountFunction({
       mocks: {
         $apollo: {
           mutate
         }
       },
-      propsData: {
-        ecosystemId: 1,
-        getProjects: () => {},
-        addProject: mutate
-      },
       data() {
         return {
-          name: "New Project",
-          title: "new-project"
+          form: {
+            name: "New Project",
+            title: "new-project"
+          }
         };
       }
     });
+    await wrapper.setProps({ saveFunction: mutate });
     await Mutations.addProject(wrapper.vm.$apollo, {
-      name: wrapper.vm.name,
-      title: wrapper.vm.title,
+      name: wrapper.vm.form.name,
+      title: wrapper.vm.form.title,
       ecosystemId: wrapper.vm.ecosystemId
     });
 
     expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for updateProject", async () => {
+    const mutate = jest.fn(() => Promise.resolve(updateProjectResponse));
+    const wrapper = mountFunction({
+      mocks: {
+        $apollo: {
+          mutate
+        },
+        $router: {
+          push: () => {}
+        }
+      },
+      data() {
+        return {
+          form: {
+            name: "test",
+            title: "Test Title",
+            parentId: 2
+          }
+        };
+      }
+    });
+    await wrapper.setProps({ saveFunction: mutate });
+
+    //Mock Vuetify form validation
+    wrapper.vm.$refs.form.validate = () => {
+      return true;
+    };
+
+    await wrapper.vm.save();
+
+    expect(mutate).toBeCalledWith({
+      ecosystemId: 1,
+      name: "test",
+      parentId: 2,
+      title: "Test Title"
+    });
     expect(wrapper.element).toMatchSnapshot();
   });
 });

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -28,7 +28,7 @@ describe("ProjectsForm queries", () => {
       propsData: {
         ecosystemId: 1,
         getProjects: Queries.getProjects,
-        addProject: () => {}
+        saveFunction: () => {}
       }
     });
     await wrapper.vm.loadParentProjects();


### PR DESCRIPTION
Users can edit a project at the `ecosystem/id/project/name/edit` route, which displays a `ProjectForm` filled with the project's information. The information is updated using the `updateProject` GraphQL mutation for the name and title and `moveProject` mutation to change the parent project.
Links to the edit route can be found on the project page or on its menu on the sidebar tree.
Closes #60.