### PR TITLE
[ui] Implement breadcrumbs component

### DIFF
--- a/ui/src/components/Breadcrumbs.stories.js
+++ b/ui/src/components/Breadcrumbs.stories.js
@@ -1,0 +1,22 @@
+import Breadcrumbs from "./Breadcrumbs";
+
+export default {
+  title: "Breadcrumbs",
+  excludeStories: /.*Data$/
+};
+
+const template = '<breadcrumbs :items="items" />';
+
+export const Default = () => ({
+  components: { Breadcrumbs },
+  template: template,
+  data() {
+    return {
+      items: [
+        { text: "ecosystem", to: "/ecosystem/test" },
+        { text: "project", to: "/ecosystem/test/project/test" },
+        { text: "New project", disabled: true }
+      ]
+    };
+  }
+});

--- a/ui/src/components/Breadcrumbs.vue
+++ b/ui/src/components/Breadcrumbs.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-breadcrumbs :items="items" class="pb-9 pl-0" />
+</template>
+
+<script>
+export default {
+  name: "Breadcrumbs",
+  props: {
+    items: {
+      type: Array,
+      required: true
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.theme--light.v-breadcrumbs ::v-deep .v-breadcrumbs__item {
+  font-size: 1rem;
+  font-weight: 300;
+  color: rgba(0, 0, 0, 0.87);
+  letter-spacing: 0.03em;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &--disabled {
+    font-weight: 700;
+    color: rgba(0, 0, 0, 0.87);
+  }
+}
+</style>

--- a/ui/src/utils/index.js
+++ b/ui/src/utils/index.js
@@ -1,0 +1,45 @@
+const getProjectBreadcrumbs = project => {
+  const breadcrumbs = [
+    {
+      text: project.name,
+      disabled: true
+    }
+  ];
+
+  function findParents(parent, ecosystem) {
+    if (parent) {
+      breadcrumbs.splice(0, 0, {
+        text: parent.name,
+        to: `/ecosystem/${ecosystem.id}/project/${parent.name}`
+      });
+      findParents(parent.parentProject, ecosystem);
+    } else {
+      breadcrumbs.splice(0, 0, {
+        text: ecosystem.name,
+        href: `/ecosystem/${ecosystem.id}`
+      });
+    }
+  }
+
+  findParents(project.parentProject, project.ecosystem);
+
+  return breadcrumbs;
+};
+
+const getViewBreadCrumbs = (view, ecosystem, parent) => {
+  if (ecosystem) {
+    const project = {
+      name: view,
+      ecosystem: {
+        id: ecosystem.id,
+        name: ecosystem.name
+      },
+      parentProject: parent
+    };
+    return getProjectBreadcrumbs(project);
+  } else {
+    return [{ text: view, disabled: true }];
+  }
+};
+
+export { getProjectBreadcrumbs, getViewBreadCrumbs };

--- a/ui/src/views/NewProject.vue
+++ b/ui/src/views/NewProject.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="pa-5">
-    <h2 class="text-body-1 font-weight-light mb-9">
-      Bestiary /
-      <span class="font-weight-bold">New project</span>
-    </h2>
+    <breadcrumbs :items="breadcrumbs" />
     <project-form
       v-if="isEcosystem"
       :ecosystemId="ecosystemId"
@@ -18,13 +15,15 @@
 </template>
 
 <script>
+import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectForm from "../components/ProjectForm";
 import { GetBasicProjectInfo } from "../apollo/queries";
 import { addProject } from "../apollo/mutations";
+import { getViewBreadCrumbs } from "../utils";
 
 export default {
   name: "NewProject",
-  components: { ProjectForm },
+  components: { Breadcrumbs, ProjectForm },
   computed: {
     ecosystemId() {
       return this.$route.params.id ? Number(this.$route.params.id) : null;
@@ -34,6 +33,9 @@ export default {
     },
     parent() {
       return this.$route.params.parent;
+    },
+    breadcrumbs() {
+      return getViewBreadCrumbs("New project", this.isEcosystem, this.parent);
     }
   },
   methods: {

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -1,13 +1,6 @@
 <template>
   <div class="pa-5" v-if="project">
-    <nav class="text-body-1 font-weight-light mb-9">
-      Bestiary / {{ project.ecosystem.name }} /
-      <span v-if="project.parentProject">
-        {{ project.parentProject.name }} /
-      </span>
-      <span class="font-weight-bold">{{ project.name }}</span>
-    </nav>
-
+    <breadcrumbs :items="breadcrumbs" />
     <v-row class="ma-0 mb-9 justify-space-between">
       <h2 class="text-h5 font-weight-medium">{{ project.title }}</h2>
       <v-btn class="primary--text button" @click="confirmDelete">
@@ -27,11 +20,13 @@
 <script>
 import { getProjectByName } from "../apollo/queries";
 import { deleteProject } from "../apollo/mutations";
+import { getProjectBreadcrumbs } from "../utils";
+import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectList from "../components/ProjectList";
 
 export default {
   name: "Project",
-  components: { ProjectList },
+  components: { Breadcrumbs, ProjectList },
   data() {
     return {
       project: null
@@ -43,6 +38,9 @@ export default {
     },
     name() {
       return this.$route.params.name;
+    },
+    breadcrumbs() {
+      return getProjectBreadcrumbs(this.project);
     }
   },
   methods: {

--- a/ui/tests/unit/Breadcrumbs.spec.js
+++ b/ui/tests/unit/Breadcrumbs.spec.js
@@ -1,0 +1,59 @@
+import { mount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import Breadcrumbs from "@/components/Breadcrumbs";
+import * as Utils from "@/utils";
+
+Vue.use(Vuetify);
+
+describe("Breadcrumbs", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return mount(Breadcrumbs, {
+      stubs: ["router-link"],
+      vuetify,
+      ...options
+    });
+  };
+  const project = {
+    name: "grandchild",
+    ecosystem: {
+      id: 1,
+      name: "ecosystem"
+    },
+    parentProject: {
+      name: "child",
+      parentProject: {
+        name: "parent"
+      }
+    }
+  };
+
+  test("Gets simple breadcrumbs", () => {
+    const items = Utils.getViewBreadCrumbs("View name");
+    const wrapper = mountFunction({ propsData: { items: items } });
+    const breadcrumbs = wrapper.find(".v-breadcrumbs__item");
+
+    expect(breadcrumbs.text()).toBe("View name");
+  });
+
+  test("Gets breadcrumbs from project", () => {
+    const items = Utils.getProjectBreadcrumbs(project);
+    const wrapper = mountFunction({ propsData: { items: items } });
+    const breadcrumbs = wrapper.findAll(".v-breadcrumbs__item");
+
+    expect(wrapper.vm.items.length).toBe(4);
+
+    const ecosystem = breadcrumbs.at(0);
+    expect(ecosystem.text()).toBe("ecosystem");
+
+    const parent = breadcrumbs.at(1);
+    expect(parent.text()).toBe("parent");
+
+    const child = breadcrumbs.at(2);
+    expect(child.text()).toBe("child");
+
+    const grandchild = breadcrumbs.at(3);
+    expect(grandchild.text()).toBe("grandchild");
+  });
+})


### PR DESCRIPTION
Adds a new `Breadcrumbs` component to the `Project` and `NewProject` views to help with navigation. The component displays a list of links that reflect the project hierarchy, eg. `ecosystem / parent project / project`.
An example of the component can be found on Storybook.
Closes #63.