### PR TITLE
[ui] Drag and drop to change a project's parent

### DIFF
--- a/ui/config/storybook/preview.js
+++ b/ui/config/storybook/preview.js
@@ -1,6 +1,8 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
+import Vuex from "vuex";
 import router from "./../../src/router";
+import store from "./../../src/store";
 import * as _Vuetify from "vuetify/lib";
 import { configure, addDecorator } from "@storybook/vue";
 import '@mdi/font/css/materialdesignicons.css';
@@ -23,6 +25,7 @@ Vue.use(Vuetify, {
 });
 
 Vue.use(VueRouter);
+Vue.use(Vuex);
 
 const VuetifyConfig = new Vuetify({
   icons: {
@@ -40,6 +43,7 @@ const VuetifyConfig = new Vuetify({
 
 addDecorator(() => ({
   router,
+  store,
   vuetify: VuetifyConfig,
   template: "<v-app><story/></v-app>"
 }));

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -6,6 +6,7 @@
         <ecosystem-tree
           :ecosystem="ecosystem"
           :delete-project="deleteProject"
+          :move-project="moveProject"
         />
         <v-btn
           :to="{ name: 'project-new', params: { id: ecosystem.id } }"
@@ -46,7 +47,7 @@
 
 <script>
 import { getEcosystems } from "./apollo/queries";
-import { deleteProject } from "./apollo/mutations";
+import { deleteProject, moveProject } from "./apollo/mutations";
 import { mapGetters } from "vuex";
 import EcosystemTree from "./components/EcosystemTree";
 import Search from "./components/Search";
@@ -95,6 +96,25 @@ export default {
     search(query) {
       this.$router.push({ name: "search", query });
       this.$refs.search.clearInput();
+    },
+    async moveProject(fromId, toId) {
+      try {
+        await moveProject(this.$apollo, fromId, toId);
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Project moved successfully",
+          color: "success"
+        });
+        this.getEcosystemsPage();
+      } catch (error) {
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
     }
   },
   created() {

--- a/ui/src/components/EcosystemTree.stories.js
+++ b/ui/src/components/EcosystemTree.stories.js
@@ -6,7 +6,7 @@ export default {
 };
 
 const ecosystemTreeTemplate = `
-  <ecosystem-tree :ecosystem="ecosystem" :delete-project="mockAction" />
+  <ecosystem-tree :ecosystem="ecosystem" :delete-project="mockAction" :move-project="mockAction" />
 `;
 
 export const Default = () => ({
@@ -20,7 +20,7 @@ export const Default = () => ({
         title: "Ecosystem",
         projectSet: [
           {
-            id: "1",
+            id: 1,
             name: "projectname",
             title: "Project 1",
             ecosystem: {
@@ -29,25 +29,27 @@ export const Default = () => ({
             parentProject: null,
             subprojects: [
               {
-                id: 2,
+                id: 5,
                 name: "subproject",
                 title: "Subproject 1",
                 ecosystem: {
                   name: "ecosystem-name"
                 },
                 parentProject: {
-                  name: "projectname"
+                  name: "projectname",
+                  id: 1
                 },
                 subprojects: [
                   {
-                    id: 3,
+                    id: 6,
                     name: "sub-subproject",
                     title: "Sub-subproject title",
                     ecosystem: {
                       name: "ecosystem-name"
                     },
                     parentProject: {
-                      name: "subproject"
+                      name: "subproject",
+                      id: 5
                     }
                   }
                 ]
@@ -60,7 +62,8 @@ export const Default = () => ({
                   name: "ecosystem-name"
                 },
                 parentProject: {
-                  name: "projectname"
+                  name: "projectname",
+                  id: 1
                 }
               }
             ]

--- a/ui/src/utils/projects.js
+++ b/ui/src/utils/projects.js
@@ -1,0 +1,37 @@
+const getRoot = project => {
+  const parent = project ? project.parentProject : null;
+  if (parent) {
+    project = getRoot(parent);
+  }
+  return project;
+};
+
+const hasSameRoot = (project, fromProject) => {
+  if (project.parentProject) {
+    return getRoot(project.parentProject).name === getRoot(fromProject).name;
+  }
+  return true;
+};
+
+const isDescendant = (project, fromProject) => {
+  const queue = [fromProject];
+  while (queue.length > 0) {
+    const current = queue.pop(0);
+    if (current.subprojects) {
+      for (let subproject of current.subprojects) {
+        if (subproject.id == project.id) {
+          return true;
+        }
+        queue.push(subproject);
+      }
+    }
+  }
+};
+
+const isParent = (project, fromProject) => {
+  return project.parentProject
+    ? fromProject.name === project.parentProject.name
+    : false;
+};
+
+export { getRoot, hasSameRoot, isDescendant, isParent };

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -59,6 +59,18 @@ export default {
     }
   },
   methods: {
+    async getProject() {
+      try {
+        const response = await getProjectByName(
+          this.$apollo,
+          this.name,
+          this.ecosystemId
+        );
+        this.project = response.data.projects.entities[0];
+      } catch (error) {
+        console.error(error);
+      }
+    },
     confirmDelete() {
       const dialog = {
         isOpen: true,
@@ -89,16 +101,12 @@ export default {
       }
     }
   },
-  async mounted() {
-    try {
-      const response = await getProjectByName(
-        this.$apollo,
-        this.name,
-        this.ecosystemId
-      );
-      this.project = response.data.projects.entities[0];
-    } catch (error) {
-      console.error(error);
+  mounted() {
+    this.getProject();
+  },
+  watch: {
+    "$store.state.ecosystems": function() {
+      this.getProject();
     }
   }
 };

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -1,14 +1,14 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import Vue from "vue";
 import Vuetify from "vuetify";
-import VueRouter from 'vue-router';
+import VueRouter from "vue-router";
 import EcosystemTree from "@/components/EcosystemTree";
 import router from "@/router";
 
-Vue.use(Vuetify)
+Vue.use(Vuetify);
 const localVue = createLocalVue();
 localVue.use(Vuetify);
-localVue.use(VueRouter)
+localVue.use(VueRouter);
 
 describe("EcosystemTree", () => {
   const threeLevels = {
@@ -25,18 +25,20 @@ describe("EcosystemTree", () => {
           name: "root",
           id: 0
         },
-        subprojects: [{
-          id: 2,
-          name: "grandchild",
-          title: "grandchild",
-          parentProject: {
-            name: "child"
-          },
-          ecosystem: {
-            name: "root",
-            id: 0
+        subprojects: [
+          {
+            id: 2,
+            name: "grandchild",
+            title: "grandchild",
+            parentProject: {
+              name: "child"
+            },
+            ecosystem: {
+              name: "root",
+              id: 0
+            }
           }
-        }]
+        ]
       },
       {
         id: 2,
@@ -60,7 +62,8 @@ describe("EcosystemTree", () => {
       router,
       propsData: {
         ecosystem: threeLevels,
-        deleteProject: () => {}
+        deleteProject: () => {},
+        moveProject: () => {}
       },
       ...options
     });
@@ -79,14 +82,174 @@ describe("EcosystemTree", () => {
     const ecosystemLink = wrapper.vm.getLink(wrapper.vm.ecosystem);
     expect(ecosystemLink).toBe("/ecosystem/0");
 
-    const projectLink = wrapper.vm.getLink(
-      wrapper.vm.ecosystem.subprojects[0]
-    );
+    const projectLink = wrapper.vm.getLink(wrapper.vm.ecosystem.subprojects[0]);
     expect(projectLink).toBe("/ecosystem/0/project/child");
 
     const subprojectLink = wrapper.vm.getLink(
       wrapper.vm.ecosystem.subprojects[0].subprojects[0]
     );
     expect(subprojectLink).toBe("/ecosystem/0/project/grandchild");
-  })
+  });
+
+  test("Allows moving projects in the same ecosystem", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "project1",
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "project2",
+      ecosystem: {
+        id: 0
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(true);
+  });
+
+  test("Does not allow moving projects in different ecosystems", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "project1",
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "project2",
+      ecosystem: {
+        id: 100
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(false);
+  });
+
+  test("Allows moving project to one with the same root", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "project1",
+            parentProject: {
+              name: "root"
+            },
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "project2",
+      parentProject: {
+        name: "root"
+      },
+      ecosystem: {
+        id: 0
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(true);
+  });
+
+  test("Does not allow moving project to a different root project", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "project1",
+            parentProject: { name: "root1" },
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "project2",
+      parentProject: { name: "root2" },
+      ecosystem: {
+        id: 0
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(false);
+  });
+
+  test("Does not allow moving project to its parent", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "child",
+            parentProject: { name: "parent" },
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "parent",
+      subprojects: [{ id: 1 }],
+      ecosystem: {
+        id: 0
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(false);
+  });
+
+  test("Does not allow moving project to a descendant", async () => {
+    const wrapper = mountFunction({
+      data() {
+        return {
+          dragged: {
+            id: 1,
+            name: "parent",
+            subprojects: [{ id: 2 }],
+            ecosystem: {
+              id: 0
+            }
+          }
+        }
+      }
+    });
+    const projectTo = {
+      id: 2,
+      name: "child",
+      parentProject: { id: 1 },
+      ecosystem: {
+        id: 0
+      }
+    };
+    const isAllowed = wrapper.vm.allowDrag(projectTo);
+    expect(isAllowed).toBe(false);
+  });
 });


### PR DESCRIPTION
Projects on `EcosystemTree` can be moved using drag and drop to change their parent. Valid parent projects are highlighted
when the project is dragged over them.

A project can be moved to another in the cases the `moveProject` mutation allows:
- Both projects belong to the same ecosystem
- The new parent is not already the project's parent.
- The new parent is not a child of the project.
- A project can't be moved to itself.
- If the projects are not root projects, they need to have the same root.

Before the move is performed, the user is prompted to confirm the action with a dialog. When the move is successful, the projects on the app sidebar are reloaded, and if the current view is `project`, it reloads the project's information.

Closes #65.