### PR TITLE
[ui] View ecosystem data

### DIFF
--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -157,7 +157,7 @@ const getEcosystemByID = (apollo, id) => {
   return response;
 };
 
-const GetBasicProjectInfo = (apollo, pageSize, page, filters) => {
+const getBasicProjectInfo = (apollo, pageSize, page, filters) => {
   const response = apollo.query({
     query: GET_BASIC_PROJECT_INFO,
     variables: {
@@ -199,7 +199,7 @@ const getProjectByName = (apollo, name, ecosystemId) => {
 export {
   getEcosystems,
   getEcosystemByID,
-  GetBasicProjectInfo,
+  getBasicProjectInfo,
   getProjects,
   getProjectByName
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -53,6 +53,31 @@ const GET_ECOSYSTEMS = gql`
   ${projectFragment}
 `;
 
+const GET_ECOSYSTEM_BY_ID = gql`
+  query GetEcosystemByID($id: ID) {
+    ecosystems(filters: { id: $id }, page: 1, pageSize: 1) {
+      entities {
+        name
+        title
+        description
+        projectSet {
+          ...projectFields
+          subprojects {
+            ...projectFields
+            subprojects {
+              ...projectFields
+              subprojects {
+                ...projectFields
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${projectFragment}
+`;
+
 const GET_BASIC_PROJECT_INFO = gql`
   query GetBasicInfo($pageSize: Int, $page: Int, $filters: ProjectFilterType) {
     projects(pageSize: $pageSize, page: $page, filters: $filters) {
@@ -121,6 +146,17 @@ const getEcosystems = (apollo, pageSize, page) => {
   return response;
 };
 
+const getEcosystemByID = (apollo, id) => {
+  const response = apollo.query({
+    query: GET_ECOSYSTEM_BY_ID,
+    variables: {
+      id: id
+    },
+    fetchPolicy: "no-cache"
+  });
+  return response;
+};
+
 const GetBasicProjectInfo = (apollo, pageSize, page, filters) => {
   const response = apollo.query({
     query: GET_BASIC_PROJECT_INFO,
@@ -160,4 +196,10 @@ const getProjectByName = (apollo, name, ecosystemId) => {
   return response;
 };
 
-export { getEcosystems, GetBasicProjectInfo, getProjects, getProjectByName };
+export {
+  getEcosystems,
+  getEcosystemByID,
+  GetBasicProjectInfo,
+  getProjects,
+  getProjectByName
+};

--- a/ui/src/components/ProjectList.vue
+++ b/ui/src/components/ProjectList.vue
@@ -68,8 +68,6 @@ export default {
           result = result.concat(
             this.flattenProjects(project.subprojects, path)
           );
-        } else {
-          result = result.concat(Object.assign(project, { path, route }));
         }
       });
       return result;

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -4,6 +4,11 @@ const router = new Router({
   mode: "history",
   routes: [
     {
+      name: "ecosystem",
+      path: "/ecosystem/:id",
+      component: () => import("../views/Ecosystem")
+    },
+    {
       name: "project-new",
       path: "/ecosystem/:id/new",
       component: () => import("../views/NewProject"),

--- a/ui/src/views/Ecosystem.vue
+++ b/ui/src/views/Ecosystem.vue
@@ -1,0 +1,66 @@
+<template>
+  <section class="pa-5" v-if="ecosystem">
+    <breadcrumbs :items="[{ text: ecosystem.name, disabled: true }]" />
+    <v-row class="ma-0 mb-9 justify-space-between">
+      <h2 class="text-h5 font-weight-medium">{{ ecosystem.title }}</h2>
+    </v-row>
+    <p class="ma-0 mb-9 text-body-1 text--secondary">
+      {{ ecosystem.description }}
+    </p>
+    <project-list :projects="projects" :ecosystem-id="id" />
+  </section>
+  <v-alert v-else-if="error" text outlined type="error" class="mt-5">
+    {{ error }}
+  </v-alert>
+</template>
+
+<script>
+import { getEcosystemByID } from "../apollo/queries";
+import Breadcrumbs from "../components/Breadcrumbs";
+import ProjectList from "../components/ProjectList";
+
+export default {
+  name: "Ecosystem",
+  components: {
+    Breadcrumbs,
+    ProjectList
+  },
+  data() {
+    return {
+      ecosystem: null,
+      error: null
+    };
+  },
+  computed: {
+    id() {
+      return this.$route.params.id;
+    },
+    projects() {
+      let projects = [];
+      if (this.ecosystem) {
+        projects = this.ecosystem.projectSet.filter(
+          project => !project.parentProject
+        );
+      }
+      return projects;
+    }
+  },
+  methods: {
+    async getEcosystemData(id = this.id) {
+      try {
+        const response = await getEcosystemByID(this.$apollo, id);
+        if (response && !response.errors) {
+          this.ecosystem = response.data.ecosystems.entities[0];
+        }
+      } catch (error) {
+        this.error = error;
+      }
+    }
+  },
+  mounted() {
+    this.getEcosystemData();
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/ui/src/views/NewProject.vue
+++ b/ui/src/views/NewProject.vue
@@ -17,7 +17,7 @@
 <script>
 import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectForm from "../components/ProjectForm";
-import { GetBasicProjectInfo } from "../apollo/queries";
+import { getBasicProjectInfo } from "../apollo/queries";
 import { addProject } from "../apollo/mutations";
 import { getViewBreadCrumbs } from "../utils";
 
@@ -40,7 +40,7 @@ export default {
   },
   methods: {
     async getProjects(ecosystem, pageSize = 50, page = 1) {
-      const response = await GetBasicProjectInfo(this.$apollo, pageSize, page, {
+      const response = await getBasicProjectInfo(this.$apollo, pageSize, page, {
         ecosystemId: ecosystem
       });
       if (response) {

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Ecosystem queries Mock query for getEcosystemByID 1`] = `<!---->`;
+
 exports[`ProjectsForm queries Mock query for getProjects 1`] = `
 <v-form-stub>
   <v-row-stub

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -3,6 +3,7 @@ import Vue from "vue";
 import Vuetify from "vuetify";
 import * as Queries from "@/apollo/queries";
 import ProjectForm from "@/components/ProjectForm";
+import Ecosystem from "@/views/Ecosystem";
 
 Vue.use(Vuetify);
 
@@ -34,6 +35,57 @@ describe("ProjectsForm queries", () => {
     await wrapper.vm.loadParentProjects();
 
     expect(querySpy).toHaveBeenCalledWith(1);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});
+
+describe("Ecosystem queries", () => {
+  const response = {
+    data: {
+      ecosystems: {
+        entities: [
+          {
+            name: "test",
+            title: "Test",
+            description: "Projects and repositories monitored",
+            projectSet: [
+              {
+                id: "72",
+                name: "test-project",
+                title: "Test Project",
+                ecosystem: {
+                  id: 1,
+                  name: "test"
+                },
+                parentProject: null,
+                subprojects: []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  };
+
+  test("Mock query for getEcosystemByID", async () => {
+    const querySpy = spyOn(Queries, "getEcosystemByID");
+    const query = jest.fn(() => Promise.resolve(response));
+    const wrapper = shallowMount(Ecosystem, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        },
+        $route: {
+          params: {
+            id: 1
+          }
+        }
+      }
+    });
+    await wrapper.vm.getEcosystemData();
+
+    expect(querySpy).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Creates a view at `/ecosystem/id` to visualize an ecosystem's metadata and the list of projects under it.
The data is fetched using the new `getEcosystemById` query.

Closes #67.