### PR TITLE
[ui] Add ecosystems

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -8,17 +8,17 @@
           :delete-project="deleteProject"
           :move-project="moveProject"
         />
-        <v-btn
-          :to="{ name: 'project-new', params: { id: ecosystem.id } }"
-          class="link"
-          color="#7a7a7a"
-          text
-          block
-        >
-          <v-icon small left>mdi-plus-box-outline</v-icon>
-          Add project
-        </v-btn>
       </div>
+      <v-btn
+        :to="{ name: 'ecosystem-new' }"
+        class="link pl-2"
+        color="#3f3f3f"
+        text
+        block
+      >
+        <v-icon small class="mr-1">mdi-plus</v-icon>
+        Add ecosystem
+      </v-btn>
     </v-navigation-drawer>
     <v-main>
       <v-container>
@@ -148,11 +148,16 @@ export default {
     text-transform: none;
     justify-content: left;
     letter-spacing: 0;
+    .mdi::before {
+      font-size: 1.1rem;
+    }
   }
 }
 
 .link.v-btn--active {
-  background: rgba(0, 55, 86, 0.12);
+  &::before {
+    opacity: 0;
+  }
   .v-btn__content {
     color: #003756;
   }

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -53,6 +53,16 @@ const UPDATE_PROJECT = gql`
   }
 `;
 
+const ADD_ECOSYSTEM = gql`
+  mutation addEcosystem($name: String!, $title: String, $description: String) {
+    addEcosystem(name: $name, title: $title, description: $description) {
+      ecosystem {
+        id
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -87,6 +97,18 @@ const moveProject = (apollo, fromProjectId, toProjectId) => {
   return response;
 };
 
+const addEcosystem = (apollo, data) => {
+  const response = apollo.mutate({
+    mutation: ADD_ECOSYSTEM,
+    variables: {
+      name: data.name,
+      title: data.title,
+      description: data.description
+    }
+  });
+  return response;
+};
+
 const updateProject = (apollo, data, id) => {
   const response = apollo.mutate({
     mutation: UPDATE_PROJECT,
@@ -98,4 +120,4 @@ const updateProject = (apollo, data, id) => {
   return response;
 };
 
-export { addProject, deleteProject, moveProject, updateProject };
+export { addProject, deleteProject, moveProject, updateProject, addEcosystem };

--- a/ui/src/components/EcosystemForm.stories.js
+++ b/ui/src/components/EcosystemForm.stories.js
@@ -1,0 +1,18 @@
+import EcosystemForm from "./EcosystemForm.vue";
+
+export default {
+  title: "EcosystemForm",
+  excludeStories: /.*Data$/
+};
+
+const template = `<ecosystem-form :save-function="mockAction" />`;
+
+export const Default = () => ({
+  components: { EcosystemForm },
+  template: template,
+  methods: {
+    mockAction() {
+      return true;
+    }
+  }
+});

--- a/ui/src/components/EcosystemForm.vue
+++ b/ui/src/components/EcosystemForm.vue
@@ -1,0 +1,128 @@
+<template>
+  <v-form ref="form">
+    <v-row>
+      <v-col cols="4">
+        <v-text-field
+          v-model="form.title"
+          :rules="validations.required"
+          label="Ecosystem title"
+          outlined
+          dense
+          @change="suggestName"
+        ></v-text-field>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <v-text-field
+          v-model="form.name"
+          :rules="validations.required"
+          label="Ecosystem name"
+          outlined
+          dense
+          @input="touchedName = true"
+        ></v-text-field>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <v-textarea
+          v-model="form.description"
+          label="Ecosystem description (optional)"
+          :rules="validations.maxLength"
+          outlined
+          dense
+          counter="128"
+          rows="4"
+        ></v-textarea>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4" class="d-flex justify-end">
+        <v-btn color="primary" depressed @click="save">
+          Save
+        </v-btn>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <v-alert v-if="error" text outlined type="error">
+          {{ error }}
+        </v-alert>
+      </v-col>
+    </v-row>
+  </v-form>
+</template>
+
+<script>
+export default {
+  name: "EcosystemForm",
+  props: {
+    saveFunction: {
+      type: Function,
+      required: true
+    },
+    id: {
+      type: [Number, String],
+      required: false
+    },
+    name: {
+      type: String,
+      required: false
+    },
+    title: {
+      type: String,
+      required: false
+    },
+    description: {
+      type: String,
+      required: false
+    }
+  },
+  data() {
+    return {
+      form: {
+        name: this.name,
+        title: this.title,
+        description: this.description
+      },
+      validations: {
+        required: [v => !!v || "Required"],
+        maxLength: [v => (v ? v.length <= 128 : true) || "Max 128 characters"]
+      },
+      touchedName: false,
+      error: null
+    };
+  },
+  methods: {
+    suggestName(value) {
+      if (value && !this.name && !this.touchedName) {
+        this.form.name = value
+          .trim()
+          .replace(/\s+/g, "-")
+          .toLowerCase();
+      }
+    },
+    async save() {
+      if (!this.$refs.form.validate()) {
+        return;
+      }
+      try {
+        const data = {
+          name: this.form.name.trim(),
+          title: this.form.title.trim(),
+          description: this.form.description
+        };
+        const response = await this.saveFunction(data);
+        if (response && !response.errors) {
+          this.$router.push({ path: `/ecosystem/${response.id}` });
+        } else if (response.errors) {
+          this.error = response.errors[0].message;
+        }
+      } catch (error) {
+        this.error = error;
+      }
+    }
+  }
+};
+</script>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -9,6 +9,11 @@ const router = new Router({
       component: () => import("../views/Ecosystem")
     },
     {
+      name: "ecosystem-new",
+      path: "/ecosystem/new",
+      component: () => import("../views/NewEcosystem")
+    },
+    {
       name: "project-new",
       path: "/ecosystem/:id/new",
       component: () => import("../views/NewProject"),

--- a/ui/src/views/NewEcosystem.vue
+++ b/ui/src/views/NewEcosystem.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="pa-5">
+    <breadcrumbs :items="[{ text: 'New ecosystem', disabled: true }]" />
+    <ecosystem-form :save-function="save" />
+  </div>
+</template>
+
+<script>
+import Breadcrumbs from "../components/Breadcrumbs";
+import EcosystemForm from "../components/EcosystemForm";
+import { addEcosystem } from "../apollo/mutations";
+
+export default {
+  name: "NewEcosystem",
+  components: {
+    Breadcrumbs,
+    EcosystemForm
+  },
+  methods: {
+    async save(data) {
+      const response = await addEcosystem(this.$apollo, data);
+      if (response) {
+        this.$emit("updateSidebar");
+        return response.data.addEcosystem.ecosystem;
+      }
+    }
+  }
+};
+</script>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1,5 +1,120 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Ecosystem mutations Mock mutation for addEcosystem 1`] = `
+<v-form-stub>
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem title"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="v => !!v || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="Test"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem name"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="v => !!v || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="test"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-textarea-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        counter="128"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem description (optional)"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rowheight="24"
+        rows="4"
+        rules="v => (v ? v.length <= 128 : true) || \\"Max 128 characters\\""
+        successmessages=""
+        type="text"
+        value="Lorem ipsum"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      class="d-flex justify-end"
+      cols="4"
+      tag="div"
+    >
+      <v-btn-stub
+        activeclass=""
+        color="primary"
+        depressed="true"
+        tag="button"
+        type="button"
+      >
+        
+        Save
+      
+      </v-btn-stub>
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <!---->
+    </v-col-stub>
+  </v-row-stub>
+</v-form-stub>
+`;
+
 exports[`ProjectsForm mutations Mock mutation for addProject 1`] = `
 <v-form-stub>
   <v-row-stub

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -3,6 +3,7 @@ import Vue from "vue";
 import Vuetify from "vuetify";
 import * as Mutations from "@/apollo/mutations";
 import ProjectForm from "@/components/ProjectForm";
+import EcosystemForm from "@/components/EcosystemForm";
 
 Vue.use(Vuetify);
 
@@ -110,6 +111,51 @@ describe("ProjectsForm mutations", () => {
       parentId: 2,
       title: "Test Title"
     });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});
+
+describe("Ecosystem mutations", () => {
+  const response = {
+    data: {
+      addEcosystem: {
+        ecosystem: {
+          id: "1"
+        }
+      }
+    }
+  };
+
+  test("Mock mutation for addEcosystem", async () => {
+    const mutate = jest.fn(() => Promise.resolve(response));
+    const wrapper = shallowMount(EcosystemForm, {
+       Vue,
+       mocks: {
+         $apollo: {
+           mutate
+         }
+       },
+       propsData: {
+         saveFunction: mutate
+       },
+       data() {
+        return {
+          form: {
+            name: "test",
+            title: "Test",
+            description: "Lorem ipsum"
+          }
+        };
+       }
+    });
+
+    await Mutations.addEcosystem(wrapper.vm.$apollo, {
+      name: wrapper.vm.form.name,
+      title: wrapper.vm.form.title,
+      description: wrapper.vm.form.description
+    });
+
+    expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR adds a view at `/ecosystem/new` that allows users to create a new ecosystem using the `addEcosystem` GraphQL mutation.
A link to this view can be found on the app sidebar, and an example of the `EcosystemForm`component on Storybook.
Closes #70.