### PR TITLE
[ui] Edit ecosystem data

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -63,6 +63,16 @@ const ADD_ECOSYSTEM = gql`
   }
 `;
 
+const UPDATE_ECOSYSTEM = gql`
+  mutation updateEcosystem($data: EcosystemInputType, $id: ID) {
+    updateEcosystem(data: $data, id: $id) {
+      ecosystem {
+        id
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -97,6 +107,17 @@ const moveProject = (apollo, fromProjectId, toProjectId) => {
   return response;
 };
 
+const updateProject = (apollo, data, id) => {
+  const response = apollo.mutate({
+    mutation: UPDATE_PROJECT,
+    variables: {
+      data: data,
+      id: id
+    }
+  });
+  return response;
+};
+
 const addEcosystem = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_ECOSYSTEM,
@@ -109,9 +130,9 @@ const addEcosystem = (apollo, data) => {
   return response;
 };
 
-const updateProject = (apollo, data, id) => {
+const updateEcosystem = (apollo, data, id) => {
   const response = apollo.mutate({
-    mutation: UPDATE_PROJECT,
+    mutation: UPDATE_ECOSYSTEM,
     variables: {
       data: data,
       id: id
@@ -120,4 +141,11 @@ const updateProject = (apollo, data, id) => {
   return response;
 };
 
-export { addProject, deleteProject, moveProject, updateProject, addEcosystem };
+export {
+  addProject,
+  deleteProject,
+  moveProject,
+  updateProject,
+  addEcosystem,
+  updateEcosystem
+};

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -15,7 +15,7 @@
     >
       <template v-slot:label="{ item }">
         <div
-          class="d-flex flex-wrap justify-space-between align-center hidden"
+          class="d-flex justify-space-between align-center hidden"
           :draggable="!item.projectSet"
           @dragstart.stop="startDrag(item, $event)"
           @drop.stop.prevent="onDrop(item, $event)"
@@ -70,20 +70,31 @@
             </v-list>
           </v-menu>
 
-          <v-tooltip right>
+          <v-menu offset-y v-else>
             <template v-slot:activator="{ on }">
-              <v-btn
-                v-if="item.projectSet"
-                :to="{ name: 'project-new', params: { id: item.id } }"
-                v-on="on"
-                color="transparent"
-                icon
-              >
-                <v-icon>mdi-plus-box-outline</v-icon>
+              <v-btn v-on="on" icon color="transparent">
+                <v-icon>mdi-dots-horizontal</v-icon>
               </v-btn>
             </template>
-            <span class="text-caption">Add a project</span>
-          </v-tooltip>
+            <v-list dense>
+              <v-list-item
+                :to="{ name: 'project-new', params: { id: item.id } }"
+              >
+                <v-list-item-icon class="mr-2">
+                  <v-icon small color="#3f3f3f">mdi-plus</v-icon>
+                </v-list-item-icon>
+                <v-list-item-title>Add a project</v-list-item-title>
+              </v-list-item>
+              <v-list-item
+                :to="{ name: 'ecosystem-edit', params: { id: item.id } }"
+              >
+                <v-list-item-icon class="mr-2">
+                  <v-icon small color="#3f3f3f">mdi-pencil-outline</v-icon>
+                </v-list-item-icon>
+                <v-list-item-title>Edit</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
         </div>
       </template>
     </v-treeview>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -14,6 +14,11 @@ const router = new Router({
       component: () => import("../views/NewEcosystem")
     },
     {
+      name: "ecosystem-edit",
+      path: "/ecosystem/:id/edit",
+      component: () => import("../views/EditEcosystem")
+    },
+    {
       name: "project-new",
       path: "/ecosystem/:id/new",
       component: () => import("../views/NewProject"),

--- a/ui/src/styles/_buttons.scss
+++ b/ui/src/styles/_buttons.scss
@@ -40,3 +40,8 @@
     border-color: rgba(0, 0, 0, 0.12);
   }
 }
+
+.button--lowercase {
+  text-transform: none;
+  letter-spacing: normal;
+}

--- a/ui/src/views/Ecosystem.vue
+++ b/ui/src/views/Ecosystem.vue
@@ -3,6 +3,13 @@
     <breadcrumbs :items="[{ text: ecosystem.name, disabled: true }]" />
     <v-row class="ma-0 mb-9 justify-space-between">
       <h2 class="text-h5 font-weight-medium">{{ ecosystem.title }}</h2>
+      <v-btn
+        class="primary--text button--lowercase"
+        :to="{ name: 'ecosystem-edit', params: { id: id } }"
+      >
+        <v-icon dense left>mdi-pencil-outline</v-icon>
+        Edit
+      </v-btn>
     </v-row>
     <p class="ma-0 mb-9 text-body-1 text--secondary">
       {{ ecosystem.description }}
@@ -63,4 +70,6 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+</style>

--- a/ui/src/views/EditEcosystem.vue
+++ b/ui/src/views/EditEcosystem.vue
@@ -1,0 +1,61 @@
+<template>
+  <div v-if="ecosystem" class="pa-5">
+    <breadcrumbs :items="breadcrumbs" />
+    <ecosystem-form
+      :save-function="save"
+      :name="ecosystem.name"
+      :title="ecosystem.title"
+      :description="ecosystem.description"
+    />
+  </div>
+</template>
+
+<script>
+import Breadcrumbs from "../components/Breadcrumbs";
+import EcosystemForm from "../components/EcosystemForm";
+import { getEcosystemByID } from "../apollo/queries";
+import { updateEcosystem } from "../apollo/mutations";
+
+export default {
+  name: "EditEcosystem",
+  components: { Breadcrumbs, EcosystemForm },
+  computed: {
+    id() {
+      return this.$route.params.id;
+    },
+    breadcrumbs() {
+      return [
+        { to: `/ecosystem/${this.id}`, text: this.ecosystem.name, exact: true },
+        { text: "Edit ecosystem", disabled: true }
+      ];
+    }
+  },
+  data() {
+    return {
+      ecosystem: null
+    };
+  },
+  methods: {
+    async getEcosystemMetadata(id = this.id) {
+      try {
+        const response = await getEcosystemByID(this.$apollo, id);
+        if (response && response.data.ecosystems.entities[0]) {
+          return response.data.ecosystems.entities[0];
+        }
+      } catch (error) {
+        this.error = error;
+      }
+    },
+    async save(data) {
+      const response = await updateEcosystem(this.$apollo, data, this.id);
+      if (response && !response.errors) {
+        this.$emit("updateSidebar");
+        return response.data.updateEcosystem.ecosystem;
+      }
+    }
+  },
+  async mounted() {
+    this.ecosystem = await this.getEcosystemMetadata(this.id);
+  }
+};
+</script>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -115,6 +115,121 @@ exports[`Ecosystem mutations Mock mutation for addEcosystem 1`] = `
 </v-form-stub>
 `;
 
+exports[`Ecosystem mutations Mock mutation for updateEcosystem 1`] = `
+<v-form-stub>
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem title"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="v => !!v || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="Test"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem name"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rules="v => !!v || \\"Required\\""
+        successmessages=""
+        type="text"
+        value="test"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <v-textarea-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        counter="128"
+        dense="true"
+        errorcount="1"
+        errormessages=""
+        label="Ecosystem description (optional)"
+        loaderheight="2"
+        messages=""
+        outlined="true"
+        rowheight="24"
+        rows="4"
+        rules="v => (v ? v.length <= 128 : true) || \\"Max 128 characters\\""
+        successmessages=""
+        type="text"
+        value="Lorem ipsum"
+      />
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      class="d-flex justify-end"
+      cols="4"
+      tag="div"
+    >
+      <v-btn-stub
+        activeclass=""
+        color="primary"
+        depressed="true"
+        tag="button"
+        type="button"
+      >
+        
+        Save
+      
+      </v-btn-stub>
+    </v-col-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    tag="div"
+  >
+    <v-col-stub
+      cols="4"
+      tag="div"
+    >
+      <!---->
+    </v-col-stub>
+  </v-row-stub>
+</v-form-stub>
+`;
+
 exports[`ProjectsForm mutations Mock mutation for addProject 1`] = `
 <v-form-stub>
   <v-row-stub

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -158,4 +158,31 @@ describe("Ecosystem mutations", () => {
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
   });
+
+  test("Mock mutation for updateEcosystem", async () => {
+    const mutate = jest.fn(() => Promise.resolve(response));
+    const wrapper = shallowMount(EcosystemForm, {
+       Vue,
+       mocks: {
+         $apollo: {
+           mutate
+         }
+       },
+       propsData: {
+         saveFunction: mutate,
+         name: "test",
+         title: "Test",
+         description: "Lorem ipsum"
+       }
+    });
+
+    await Mutations.updateEcosystem(wrapper.vm.$apollo, {
+      name: wrapper.vm.form.name,
+      title: wrapper.vm.form.title,
+      description: wrapper.vm.form.description
+    });
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This PR adds a view at `/ecosystem/id/edit` to allow users to modify an ecosystem's metadata using the `updateEcosystem` mutation.
A link to this route is added to the ecosystem's page and to the item's menu at the `EcosystemTree` on the sidebar.
Closes #69.