### PR TITLE
Move projects to ancestors

### DIFF
--- a/bestiary/core/api.py
+++ b/bestiary/core/api.py
@@ -314,8 +314,7 @@ def move_project(ctx, from_project_id, to_project_id):
     """Move a project to a parent project.
 
     Link a project with another one with a child-parent relation. If a project
-    is not linked to any project, it is a root project. Once the project is linked
-    with another one, it won't be a root project anymore.
+    is not linked to any project, it is a root project.
     If the source project was already linked to a parent project, it will be
     overwritten.
 
@@ -343,7 +342,7 @@ def move_project(ctx, from_project_id, to_project_id):
         raise exc
 
     try:
-        to_project = find_project(to_project_id)
+        to_project = find_project(to_project_id) if to_project_id else None
     except ValueError as e:
         raise InvalidValueError(msg=str(e))
     except NotFoundError as exc:

--- a/bestiary/core/db.py
+++ b/bestiary/core/db.py
@@ -382,14 +382,14 @@ def link_parent_project(trxl, project, parent_project):
     # Setting operation arguments before they are modified
     op_args = {
         'id': project.id,
-        'parent_id': parent_project.id
+        'parent_id': parent_project.id if parent_project else None
     }
 
     if project.parent_project == parent_project:
         raise ValueError('Parent is already set to the project')
     if project == parent_project:
         raise ValueError('Project cannot be its own parent')
-    if project.ecosystem != parent_project.ecosystem:
+    if parent_project and (project.ecosystem != parent_project.ecosystem):
         raise ValueError('Parent cannot belong to a different ecosystem')
     if _is_descendant(parent_project, project):
         raise ValueError('Parent cannot be a descendant')

--- a/bestiary/core/db.py
+++ b/bestiary/core/db.py
@@ -345,8 +345,6 @@ def link_parent_project(trxl, project, parent_project):
       - The parent is already set to the project.
       - The parent and the project are the same.
       - The parent belongs to a different ecosystem.
-      - If the project is not a root one, when the parent comes from a
-       different root project.
       - The parent is a descendant from the project.
 
     :param trxl: TransactionsLog object from the method calling this one
@@ -357,17 +355,6 @@ def link_parent_project(trxl, project, parent_project):
 
     :raises ValueError: raised either when the given parent project is invalid
     """
-    def _get_root(project):
-        """Return the root project given one of its subprojects"""
-
-        parent = None
-        if project:
-            parent = project.parent_project
-        if parent:
-            project = _get_root(parent)
-
-        return project
-
     def _is_descendant(project, from_project):
         """Check if a project is a descendant of another"""
 
@@ -393,12 +380,6 @@ def link_parent_project(trxl, project, parent_project):
         raise ValueError('Parent cannot belong to a different ecosystem')
     if _is_descendant(parent_project, project):
         raise ValueError('Parent cannot be a descendant')
-
-    from_root = _get_root(project)
-    to_root = _get_root(parent_project)
-    # If `from_project` is not a root project, its parent cannot belong to another root
-    if (project.parent_project) and (from_root != to_root):
-        raise ValueError('Parent cannot belong to a different root project')
 
     project.parent_project = parent_project
 

--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -471,13 +471,13 @@ class MoveProject(graphene.Mutation):
     project = graphene.Field(lambda: ProjectType)
 
     @check_auth
-    def mutate(self, info, from_project_id, to_project_id):
+    def mutate(self, info, from_project_id, to_project_id=None):
         user = info.context.user
         ctx = BestiaryContext(user)
 
         # Forcing this conversion explicitly, as input value is taken as a string
         from_project_id_value = int(from_project_id)
-        to_project_id_value = int(to_project_id)
+        to_project_id_value = int(to_project_id) if to_project_id else None
 
         project = move_project(ctx,
                                from_project_id_value,

--- a/releases/unreleased/move-ancestors.yml
+++ b/releases/unreleased/move-ancestors.yml
@@ -1,0 +1,11 @@
+---
+title: Move projects to any ancestor
+category: changed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 74
+notes: >
+    This change allows projects to be moved to any ancestor.
+
+    Projects can be moved to another project that belongs to
+    a different root. Also, a parent relation can be removed,
+    making a project a root one.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1647,28 +1647,6 @@ class TestMoveProject(TestCase):
         transactions = Transaction.objects.filter(created_at__gte=timestamp)
         self.assertEqual(len(transactions), 0)
 
-    def test_parent_different_root_project(self):
-        """Check if it fails when trying set as parent a project from a different root project"""
-
-        root1 = api.add_project(self.ctx,
-                                ecosystem_id=self.origin_eco.id,
-                                name='root-1')
-        child1 = api.add_project(self.ctx,
-                                 ecosystem_id=self.origin_eco.id,
-                                 name='example-child',
-                                 parent_id=root1.id)
-
-        timestamp = datetime_utcnow()
-
-        with self.assertRaisesRegex(ValueError, PROJECT_INVALID_PARENT_DIFFERENT_ROOT):
-            api.move_project(self.ctx,
-                             child1.id,
-                             self.parent_project.id)
-
-        # Check if there are no transactions created when there is an error
-        transactions = Transaction.objects.filter(created_at__gte=timestamp)
-        self.assertEqual(len(transactions), 0)
-
     def test_parent_already_set(self):
         """Check if it fails when the project already has that parent"""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1751,6 +1751,21 @@ class TestMoveProject(TestCase):
         transactions = Transaction.objects.filter(created_at__gte=timestamp)
         self.assertEqual(len(transactions), 0)
 
+    def test_no_parent(self):
+        """Check if removes the parent project when None is given"""
+
+        project = api.move_project(self.ctx,
+                                   self.project.id,
+                                   to_project_id=self.parent_project.id)
+
+        self.assertEqual(project.parent_project, self.parent_project)
+
+        project = api.move_project(self.ctx,
+                                   self.project.id,
+                                   to_project_id=None)
+
+        self.assertEqual(project.parent_project, None)
+
     def test_transaction(self):
         """Check if a transaction is created when moving a project"""
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1166,6 +1166,20 @@ class TestLinkParentProject(TestCase):
         operations = Operation.objects.filter(timestamp__gte=timestamp)
         self.assertEqual(len(operations), 0)
 
+    def test_remove_parent(self):
+        """Check if setting a parent project to None removes it"""
+
+        parent_proj = Project.objects.create(id=2,
+                                             name='example-parent',
+                                             title='Project title',
+                                             ecosystem=self.ecosystem)
+
+        proj = db.link_parent_project(self.trxl, self.project, parent_proj)
+        self.assertEqual(proj.parent_project, parent_proj)
+
+        proj = db.link_parent_project(self.trxl, self.project, None)
+        self.assertEqual(proj.parent_project, None)
+
     def test_operations(self):
         """Check if the right operations are created"""
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1110,24 +1110,6 @@ class TestLinkParentProject(TestCase):
         operations = Operation.objects.filter(timestamp__gte=timestamp)
         self.assertEqual(len(operations), 0)
 
-    def test_parent_different_root_project(self):
-        """Check if it fails when trying set as parent a project from a different root project"""
-
-        root1 = Project.objects.create(name='root-1',
-                                       ecosystem=self.ecosystem)
-        child1 = Project.objects.create(name='example-child-1',
-                                        ecosystem=self.ecosystem,
-                                        parent_project=root1)
-
-        timestamp = datetime_utcnow()
-
-        with self.assertRaisesRegex(ValueError, PROJECT_PARENT_DIFFERENT_ROOT):
-            db.link_parent_project(self.trxl, child1, self.project)
-
-        # Check if operations have not been generated after the failure
-        operations = Operation.objects.filter(timestamp__gte=timestamp)
-        self.assertEqual(len(operations), 0)
-
     def test_set_descendant_as_parent(self):
         """Check if it fails when trying set as parent a child project"""
 

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script>
-import { hasSameRoot, isDescendant, isParent } from "../utils/projects";
+import { isDescendant, isParent } from "../utils/projects";
 export default {
   name: "EcosystemTree",
   props: {
@@ -194,21 +194,27 @@ export default {
       if (this.dragged && item.ecosystem) {
         return (
           item.ecosystem.id === this.dragged.ecosystem.id &&
-          hasSameRoot(this.dragged, item) &&
           !isParent(this.dragged, item) &&
           !isDescendant(item, this.dragged) &&
           item.id !== this.dragged.id
         );
+      } else if (
+        this.dragged &&
+        this.dragged.parentProject &&
+        item.projectSet
+      ) {
+        return this.dragged.ecosystem.id === item.id;
       }
       return false;
     },
     onDrop(item) {
       if (this.dragged && this.allowDrag(item)) {
         const project = this.dragged.id;
+        const id = item.ecosystem ? item.id : null;
         const dialog = {
           isOpen: true,
           title: `Move project ${this.dragged.title} to ${item.title}?`,
-          action: () => this.moveProject(project, item.id)
+          action: () => this.moveProject(project, id)
         };
         this.$store.commit("setDialog", dialog);
         this.active = this.active.filter(project => project.name === item.name);

--- a/ui/src/components/ProjectForm.vue
+++ b/ui/src/components/ProjectForm.vue
@@ -125,7 +125,7 @@ export default {
       const data = {
         name: this.form.name.trim(),
         title: this.form.title,
-        parentId: this.form.parentId ? Number(this.form.parentId) : null,
+        parentId: this.form.parentId,
         ecosystemId: this.ecosystemId
       };
       const response = await this.saveFunction(data);

--- a/ui/src/views/EditProject.vue
+++ b/ui/src/views/EditProject.vue
@@ -86,13 +86,7 @@ export default {
           this.project.id
         );
         if (response && !response.errors) {
-          if (
-            formData.parentId &&
-            formData.parentId.toString() !==
-              (this.project.parentProject
-                ? this.project.parentProject.id.toString()
-                : null)
-          ) {
+          if (this.project.parentProject?.id !== formData.parentId) {
             try {
               await this.moveProject(this.project.id, formData.parentId);
             } catch (error) {
@@ -115,26 +109,11 @@ export default {
       return projects.filter(project => {
         if (project.name === this.name) {
           return false;
-        } else if (
-          this.project.parentProject &&
-          this.getRoot(this.project.parentProject).id !==
-            this.getRoot(project).id
-        ) {
-          // If the project is not a root one, when the parent comes from a
-          // different root project.
-          return false;
         } else if (this.isDescendant(project, this.project)) {
           return false;
         }
         return true;
       });
-    },
-    getRoot(project) {
-      const parent = project ? project.parentProject : null;
-      if (parent) {
-        project = this.getRoot(parent);
-      }
-      return project;
     },
     isDescendant(project, fromProject) {
       const queue = [fromProject];

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -173,7 +173,7 @@ describe("EcosystemTree", () => {
     expect(isAllowed).toBe(true);
   });
 
-  test("Does not allow moving project to a different root project", async () => {
+  test("Allows moving subproject to ecosystem root", async () => {
     const wrapper = mountFunction({
       data() {
         return {
@@ -188,16 +188,13 @@ describe("EcosystemTree", () => {
         }
       }
     });
-    const projectTo = {
-      id: 2,
-      name: "project2",
-      parentProject: { name: "root2" },
-      ecosystem: {
-        id: 0
-      }
+    const ecosystemTo = {
+      id: 0,
+      name: "ecosystem",
+      projectSet: []
     };
-    const isAllowed = wrapper.vm.allowDrag(projectTo);
-    expect(isAllowed).toBe(false);
+    const isAllowed = wrapper.vm.allowDrag(ecosystemTo);
+    expect(isAllowed).toBe(true);
   });
 
   test("Does not allow moving project to its parent", async () => {

--- a/ui/tests/unit/EditProject.spec.js
+++ b/ui/tests/unit/EditProject.spec.js
@@ -77,34 +77,4 @@ describe("EditProject", () => {
     expect(validParents.length).toBe(1);
     expect(validParents[0].name).toBe("root2");
   });
-
-  test("Filters out other root projects for children", async () => {
-    const wrapper = mountFunction({
-      mocks: {
-        $route: {
-          params: {
-            id: 3,
-            name: "child"
-          }
-        }
-      },
-      data() {
-        return {
-          project: {
-            id: 3,
-            name: "child",
-            parentProject: {
-              id: 1,
-              name: "root1"
-            },
-            ecosystem: { name: "ecosystem" }
-          }
-        };
-      }
-    });
-
-    const validParents = wrapper.vm.validateParentProjects(parentProjects);
-    expect(validParents.length).toBe(1);
-    expect(validParents[0].name).toBe("root1");
-  });
 });


### PR DESCRIPTION
Allows moving a project to a parent with a different root and to remove a project's parent, both from the GraphQL API and from the UI.
Fixes #74.