### PR TITLE
[ui] Delete ecosystems from the UI

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,6 +7,7 @@
           :ecosystem="ecosystem"
           :delete-project="deleteProject"
           :move-project="moveProject"
+          :delete-ecosystem="deleteEcosystem"
         />
       </div>
       <v-btn
@@ -47,7 +48,11 @@
 
 <script>
 import { getEcosystems } from "./apollo/queries";
-import { deleteProject, moveProject } from "./apollo/mutations";
+import {
+  deleteProject,
+  moveProject,
+  deleteEcosystem
+} from "./apollo/mutations";
 import { mapGetters } from "vuex";
 import EcosystemTree from "./components/EcosystemTree";
 import Search from "./components/Search";
@@ -81,6 +86,25 @@ export default {
         this.$store.commit("setSnackbar", {
           isOpen: true,
           text: "Project deleted successfully",
+          color: "success"
+        });
+        this.getEcosystemsPage();
+      } catch (error) {
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+    },
+    async deleteEcosystem(id) {
+      try {
+        await deleteEcosystem(this.$apollo, id);
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Ecosystem deleted successfully",
           color: "success"
         });
         this.getEcosystemsPage();

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -73,6 +73,16 @@ const UPDATE_ECOSYSTEM = gql`
   }
 `;
 
+const DELETE_ECOSYSTEM = gql`
+  mutation deleteEcosystem($id: ID!) {
+    deleteEcosystem(id: $id) {
+      ecosystem {
+        id
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -141,11 +151,22 @@ const updateEcosystem = (apollo, data, id) => {
   return response;
 };
 
+const deleteEcosystem = (apollo, id) => {
+  const response = apollo.mutate({
+    mutation: DELETE_ECOSYSTEM,
+    variables: {
+      id: id
+    }
+  });
+  return response;
+};
+
 export {
   addProject,
   deleteProject,
   moveProject,
   updateProject,
   addEcosystem,
-  updateEcosystem
+  updateEcosystem,
+  deleteEcosystem
 };

--- a/ui/src/components/EcosystemTree.stories.js
+++ b/ui/src/components/EcosystemTree.stories.js
@@ -6,7 +6,12 @@ export default {
 };
 
 const ecosystemTreeTemplate = `
-  <ecosystem-tree :ecosystem="ecosystem" :delete-project="mockAction" :move-project="mockAction" />
+  <ecosystem-tree
+    :ecosystem="ecosystem"
+    :delete-project="mockAction"
+    :move-project="mockAction"
+    :delete-ecosystem="mockAction"
+  />
 `;
 
 export const Default = () => ({

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -61,7 +61,7 @@
                 </v-list-item-icon>
                 <v-list-item-title>Edit</v-list-item-title>
               </v-list-item>
-              <v-list-item @click="confirmDelete(item)">
+              <v-list-item @click="confirmDeleteProject(item)">
                 <v-list-item-icon class="mr-2">
                   <v-icon small color="#3f3f3f">mdi-trash-can-outline</v-icon>
                 </v-list-item-icon>
@@ -93,6 +93,12 @@
                 </v-list-item-icon>
                 <v-list-item-title>Edit</v-list-item-title>
               </v-list-item>
+              <v-list-item @click="confirmDeleteEcosystem(item)">
+                <v-list-item-icon class="mr-2">
+                  <v-icon small color="#3f3f3f">mdi-trash-can-outline</v-icon>
+                </v-list-item-icon>
+                <v-list-item-title>Delete</v-list-item-title>
+              </v-list-item>
             </v-list>
           </v-menu>
         </div>
@@ -116,6 +122,10 @@ export default {
       required: true
     },
     moveProject: {
+      type: Function,
+      required: true
+    },
+    deleteEcosystem: {
       type: Function,
       required: true
     }
@@ -145,12 +155,21 @@ export default {
         return `/ecosystem/${item.ecosystem.id}/project/${item.name}`;
       }
     },
-    confirmDelete(item) {
+    confirmDeleteProject(item) {
       const dialog = {
         isOpen: true,
         title: `Delete project ${item.title}?`,
         warning: "This will delete every project inside it.",
         action: () => this.deleteProject(item.id)
+      };
+      this.$store.commit("setDialog", dialog);
+    },
+    confirmDeleteEcosystem(item) {
+      const dialog = {
+        isOpen: true,
+        title: `Delete ecosystem ${item.title}?`,
+        warning: "This will delete every project inside it.",
+        action: () => this.deleteEcosystem(item.id)
       };
       this.$store.commit("setDialog", dialog);
     },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -4,14 +4,14 @@ const router = new Router({
   mode: "history",
   routes: [
     {
-      name: "ecosystem",
-      path: "/ecosystem/:id",
-      component: () => import("../views/Ecosystem")
-    },
-    {
       name: "ecosystem-new",
       path: "/ecosystem/new",
       component: () => import("../views/NewEcosystem")
+    },
+    {
+      name: "ecosystem",
+      path: "/ecosystem/:id",
+      component: () => import("../views/Ecosystem")
     },
     {
       name: "ecosystem-edit",

--- a/ui/src/views/Ecosystem.vue
+++ b/ui/src/views/Ecosystem.vue
@@ -3,13 +3,19 @@
     <breadcrumbs :items="[{ text: ecosystem.name, disabled: true }]" />
     <v-row class="ma-0 mb-9 justify-space-between">
       <h2 class="text-h5 font-weight-medium">{{ ecosystem.title }}</h2>
-      <v-btn
-        class="primary--text button--lowercase"
-        :to="{ name: 'ecosystem-edit', params: { id: id } }"
-      >
-        <v-icon dense left>mdi-pencil-outline</v-icon>
-        Edit
-      </v-btn>
+      <div>
+        <v-btn
+          class="primary--text button--lowercase mr-6"
+          :to="{ name: 'ecosystem-edit', params: { id: id } }"
+        >
+          <v-icon dense left>mdi-pencil-outline</v-icon>
+          Edit
+        </v-btn>
+        <v-btn class="primary--text button--lowercase" @click="confirmDelete">
+          <v-icon dense left>mdi-trash-can-outline</v-icon>
+          Delete
+        </v-btn>
+      </div>
     </v-row>
     <p class="ma-0 mb-9 text-body-1 text--secondary">
       {{ ecosystem.description }}
@@ -23,6 +29,7 @@
 
 <script>
 import { getEcosystemByID } from "../apollo/queries";
+import { deleteEcosystem } from "../apollo/mutations";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectList from "../components/ProjectList";
 
@@ -61,6 +68,35 @@ export default {
         }
       } catch (error) {
         this.error = error;
+      }
+    },
+    confirmDelete() {
+      const dialog = {
+        isOpen: true,
+        title: `Delete ecosystem ${this.ecosystem.title}?`,
+        warning: "This will delete every project inside it.",
+        action: () => this.deleteEcosystem(this.id)
+      };
+      this.$store.commit("setDialog", dialog);
+    },
+    async deleteEcosystem(id) {
+      try {
+        await deleteEcosystem(this.$apollo, id);
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Ecosystem deleted successfully",
+          color: "success"
+        });
+        this.$emit("updateSidebar");
+        this.$router.push("/");
+      } catch (error) {
+        this.$store.commit("clearDialog");
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
       }
     }
   },

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -63,7 +63,8 @@ describe("EcosystemTree", () => {
       propsData: {
         ecosystem: threeLevels,
         deleteProject: () => {},
-        moveProject: () => {}
+        moveProject: () => {},
+        deleteEcosystem: () => {}
       },
       ...options
     });

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -115,6 +115,37 @@ exports[`Ecosystem mutations Mock mutation for addEcosystem 1`] = `
 </v-form-stub>
 `;
 
+exports[`Ecosystem mutations Mock mutation for deleteEcosystem 1`] = `
+<div>
+  <v-treeview-stub
+    active=""
+    activeclass="dropzone"
+    color="primary"
+    dense="true"
+    expandicon="mdi-chevron-down"
+    hoverable="true"
+    indeterminateicon="$checkboxIndeterminate"
+    itemchildren="subprojects"
+    itemdisabled="disabled"
+    itemkey="name"
+    items="[object Object]"
+    itemtext="title"
+    loadingicon="$loading"
+    officon="$checkboxOff"
+    onicon="$checkboxOn"
+    open=""
+    openall="true"
+    selectedcolor="accent"
+    selectiontype="leaf"
+    value=""
+  />
+   
+  <div
+    class="drag-image"
+  />
+</div>
+`;
+
 exports[`Ecosystem mutations Mock mutation for updateEcosystem 1`] = `
 <v-form-stub>
   <v-row-stub

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -4,6 +4,7 @@ import Vuetify from "vuetify";
 import * as Mutations from "@/apollo/mutations";
 import ProjectForm from "@/components/ProjectForm";
 import EcosystemForm from "@/components/EcosystemForm";
+import EcosystemTree from "@/components/EcosystemTree";
 
 Vue.use(Vuetify);
 
@@ -181,6 +182,35 @@ describe("Ecosystem mutations", () => {
       title: wrapper.vm.form.title,
       description: wrapper.vm.form.description
     });
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for deleteEcosystem", async () => {
+    const mutate = jest.fn(() => Promise.resolve(response));
+    const wrapper = shallowMount(EcosystemTree, {
+       Vue,
+       mocks: {
+         $apollo: {
+           mutate
+         }
+       },
+       propsData: {
+         ecosystem: {
+           id: 1,
+           title: "Test"
+         },
+         deleteEcosystem: mutate,
+         deleteProject: () => {},
+         moveProject: () => {}
+       }
+    });
+
+    await Mutations.deleteEcosystem(
+      wrapper.vm.$apollo,
+      wrapper.vm.ecosystem.id
+    );
 
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();


### PR DESCRIPTION
This PR allows users to remove ecosystems from the database by clicking a 'delete' button found on their page (/ecosystem/id) and on ecosystem's menu in the sidebar.
Closes #76.