### PR TITLE
[jobs] Add support for redis queue jobs

### DIFF
--- a/bestiary/core/jobs.py
+++ b/bestiary/core/jobs.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2021 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+
+import django_rq
+import django_rq.utils
+
+from .errors import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+def find_job(job_id):
+    """Find a job in the jobs registry.
+    Search for a job using its identifier. When the job is
+    not found, a `NotFoundError` exception is raised.
+    :param job_id: job identifier
+    :returns: a Job instance
+    :raises NotFoundError: when the job identified by `job_id`
+        is not found.
+    """
+    logger.debug(f"Finding job {job_id} ...")
+
+    queue = django_rq.get_queue()
+    jobs = django_rq.utils.get_jobs(queue, [job_id])
+
+    if not jobs:
+        logger.debug(f"Job with id {job_id} does not exist")
+        raise NotFoundError(entity=job_id)
+
+    logger.debug(f"Job with id {job_id} was found")
+
+    return jobs[0]
+
+
+def get_jobs():
+    """Get a list of all jobs
+    This function returns a list of all jobs found in the main queue and its
+    registries, sorted by date.
+    :returns: a list of Job instances
+    """
+    logger.debug("Retrieving list of jobs ...")
+
+    queue = django_rq.get_queue()
+    started_jobs = [find_job(id)
+                    for id
+                    in queue.started_job_registry.get_job_ids()]
+    deferred_jobs = [find_job(id)
+                     for id
+                     in queue.deferred_job_registry.get_job_ids()]
+    finished_jobs = [find_job(id)
+                     for id
+                     in queue.finished_job_registry.get_job_ids()]
+    failed_jobs = [find_job(id)
+                   for id
+                   in queue.failed_job_registry.get_job_ids()]
+    scheduled_jobs = [find_job(id)
+                      for id
+                      in queue.scheduled_job_registry.get_job_ids()]
+    jobs = (queue.jobs + started_jobs + deferred_jobs + finished_jobs + failed_jobs + scheduled_jobs)
+
+    sorted_jobs = sorted(jobs, key=lambda x: x.enqueued_at)
+
+    logger.debug(f"List of jobs retrieved; total jobs: {len(sorted_jobs)};")
+
+    return sorted_jobs

--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -89,6 +89,7 @@ STATIC_URL = '/static/'
 SECRET_KEY = 'fake-key'
 
 INSTALLED_APPS = [
+    'django_rq',
     'bestiary.core',
     'graphene_django',
     'django.contrib.admin',
@@ -128,4 +129,14 @@ GRAPHENE = {
     'MIDDLEWARE': [
         'graphql_jwt.middleware.JSONWebTokenMiddleware',
     ],
+}
+
+RQ_QUEUES = {
+    'default': {
+        'HOST': 'localhost',
+        'PORT': 6379,
+        'DB': 0,
+        'ASYNC': True
+
+    }
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,6 +18,26 @@ python-versions = ">=3.5"
 tests = ["pytest", "pytest-asyncio"]
 
 [[package]]
+name = "click"
+version = "8.0.1"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "django"
 version = "3.1"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
@@ -58,6 +78,40 @@ Django = ">=1.11"
 graphene-django = ">=2.1.5"
 graphql-core = ">=2.1,<3"
 PyJWT = ">=1.5.0"
+
+[[package]]
+name = "django-rq"
+version = "2.4.1"
+description = "An app that provides django integration for RQ (Redis Queue)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+django = ">=2.0"
+redis = ">=3"
+rq = ">=1.2"
+
+[package.extras]
+Sentry = ["raven (>=6.1.0)"]
+testing = ["mock (>=2.0.0)"]
+
+[[package]]
+name = "fakeredis"
+version = "1.5.2"
+description = "Fake implementation of redis API for testing purposes."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+redis = "<3.6.0"
+six = ">=1.12"
+sortedcontainers = "*"
+
+[package.extras]
+aioredis = ["aioredis (<2)"]
+lua = ["lupa"]
 
 [[package]]
 name = "flake8"
@@ -159,7 +213,7 @@ python-dateutil = ">=2.8.0,<3.0.0"
 name = "importlib-metadata"
 version = "4.6.3"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -251,6 +305,29 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "redis"
+version = "3.5.3"
+description = "Python client for Redis key-value store"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+hiredis = ["hiredis (>=0.1.3)"]
+
+[[package]]
+name = "rq"
+version = "1.9.0"
+description = "RQ is a simple, lightweight, library for creating background jobs, and processing them."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+click = ">=5.0.0"
+redis = ">=3.5.0"
+
+[[package]]
 name = "rx"
 version = "1.6.1"
 description = "Reactive Extensions (Rx) for Python"
@@ -282,6 +359,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "sqlparse"
 version = "0.4.1"
 description = "A non-validating SQL parser."
@@ -301,7 +386,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -309,7 +394,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -320,7 +405,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "b5c33e4bdd4bee03ce52491a3fafa75e70862fdb798cece807b6171769945c59"
+content-hash = "08ef99ea79431bd28dcf6b6b4002b869ac72d648b6803580724220cceb250196"
 
 [metadata.files]
 aniso8601 = [
@@ -330,6 +415,14 @@ aniso8601 = [
 asgiref = [
     {file = "asgiref-3.2.10-py3-none-any.whl", hash = "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"},
     {file = "asgiref-3.2.10.tar.gz", hash = "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a"},
+]
+click = [
+    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
+    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 django = [
     {file = "Django-3.1-py3-none-any.whl", hash = "sha256:1a63f5bb6ff4d7c42f62a519edc2adbb37f9b78068a5a862beff858b68e3dc8b"},
@@ -342,6 +435,14 @@ django-cors-headers = [
 django-graphql-jwt = [
     {file = "django-graphql-jwt-0.3.1.tar.gz", hash = "sha256:468e09b8ce67324fcba21dc33b7c1ea9d234bfc10df7cbfe9c5477be0302f933"},
     {file = "django_graphql_jwt-0.3.1-py2.py3-none-any.whl", hash = "sha256:2189f6d1a13b827d486780fa74a631a15e4f7f0235a3a87a487736b5b0dc4690"},
+]
+django-rq = [
+    {file = "django-rq-2.4.1.tar.gz", hash = "sha256:f09059ab37403a47c7933bca396fabb7f3058732d132462eade5333bc4bcac5f"},
+    {file = "django_rq-2.4.1-py2.py3-none-any.whl", hash = "sha256:23981f83c537178cbbf730f192c13e99cede2204e9d917b1c1c80c42215dd227"},
+]
+fakeredis = [
+    {file = "fakeredis-1.5.2-py3-none-any.whl", hash = "sha256:f1ffdb134538e6d7c909ddfb4fc5edeb4a73d0ea07245bc69b8135fbc4144b04"},
+    {file = "fakeredis-1.5.2.tar.gz", hash = "sha256:18fc1808d2ce72169d3f11acdb524a00ef96bd29970c6d34cfeb2edb3fc0c020"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -405,6 +506,14 @@ pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
+redis = [
+    {file = "redis-3.5.3-py2.py3-none-any.whl", hash = "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"},
+    {file = "redis-3.5.3.tar.gz", hash = "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2"},
+]
+rq = [
+    {file = "rq-1.9.0-py2.py3-none-any.whl", hash = "sha256:7af1e9706dbe6f1eac16dffacd8271ec27c1369950941f14dab6bb08a62979d7"},
+    {file = "rq-1.9.0.tar.gz", hash = "sha256:bdfef943de838955e474cfd0e25b9b8c53ed4b9c361fe4bb11cf56d17a87acc5"},
+]
 rx = [
     {file = "Rx-1.6.1-py2.py3-none-any.whl", hash = "sha256:7357592bc7e881a95e0c2013b73326f704953301ab551fbc8133a6fadab84105"},
     {file = "Rx-1.6.1.tar.gz", hash = "sha256:13a1d8d9e252625c173dc795471e614eadfe1cf40ffc684e08b8fff0d9748c23"},
@@ -416,6 +525,10 @@ singledispatch = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 sqlparse = [
     {file = "sqlparse-0.4.1-py3-none-any.whl", hash = "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,12 @@ graphene-django = "^2"
 django-graphql-jwt = "^0.3.0"
 PyJWT = "^1.7.0"
 django-cors-headers = "^3.7.0"
+rq = "^1.4.1"
+django-rq = "^2.3.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"
+fakeredis = "^1.5.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ graphene-django>=2.0,<3
 django-graphql-jwt==0.3.1
 PyJWT>=1.7.0,<2.0
 django-cors-headers
+rq>=1.4.0
+django-rq>=2.3.0
+fakeredis>=1.4.1

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2021 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Jose Javier Merchante <jjmerchante@cauldron.io>
+#
+
+from unittest import TestCase
+
+from django_rq import enqueue
+
+from bestiary.core.errors import NotFoundError
+from bestiary.core.jobs import find_job
+
+
+JOB_NOT_FOUND_ERROR = "DEF not found in the registry"
+
+
+def job_echo(s):
+    """Function to test job queuing"""
+    return s
+
+
+class TestFindJob(TestCase):
+    """Unit tests for find_job"""
+
+    def test_find_job(self):
+        """Check if it finds a job in the registry"""
+
+        job = enqueue(job_echo, 'ABC')
+        qjob = find_job(job.id)
+        self.assertEqual(qjob, job)
+
+    def test_not_found_job(self):
+        """Check if it raises an exception when the job is not found"""
+
+        enqueue(job_echo, 'ABC')
+
+        with self.assertRaisesRegex(NotFoundError,
+                                    JOB_NOT_FOUND_ERROR):
+            find_job('DEF')


### PR DESCRIPTION
This PR adds support for redis queues.
It includes a function to get a job by its ID and another to get the list of the available jobs in the registry.

I couldn't test get_jobs() method using fakeredis but I tested it with a redis server and a worker and it works.

Related to https://github.com/chaoss/grimoirelab-bestiary/issues/87