### PR TITLE
Visualize data sources

### DIFF
--- a/bestiary/core/schema.py
+++ b/bestiary/core/schema.py
@@ -703,6 +703,8 @@ class BestiaryQuery(graphene.ObjectType):
             query = query.filter(datasource__type=filters['datasource_name'])
         if filters and 'category' in filters:
             query = query.filter(category=filters['category'])
+        if filters and 'uri' in filters:
+            query = query.filter(datasource__uri=filters['uri'])
 
         return DatasetPaginatedType.create_paginated_result(query,
                                                             page,

--- a/ui/config/storybook/preview.js
+++ b/ui/config/storybook/preview.js
@@ -35,7 +35,8 @@ const VuetifyConfig = new Vuetify({
     themes: {
       light: {
         primary: "#003756",
-        secondary: "#f4bc00"
+        secondary: "#f4bc00",
+        "info--background": "#e4f2fE"
       }
     }
   }

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -24,6 +24,19 @@ const projectFragment = gql`
   }
 `;
 
+const datasetFragment = gql`
+  fragment datasetFields on DatasetType {
+    datasource {
+      type {
+        name
+      }
+      uri
+    }
+    filters
+    category
+  }
+`;
+
 const GET_ECOSYSTEMS = gql`
   query GetEcosystems($pageSize: Int, $page: Int) {
     ecosystems(pageSize: $pageSize, page: $page) {
@@ -119,6 +132,9 @@ const GET_PROJECT_BY_NAME = gql`
     projects(pageSize: 1, page: 1, filters: $filters) {
       entities {
         ...projectFields
+        datasetSet {
+          ...datasetFields
+        }
         subprojects {
           ...projectFields
           subprojects {
@@ -132,6 +148,7 @@ const GET_PROJECT_BY_NAME = gql`
     }
   }
   ${projectFragment}
+  ${datasetFragment}
 `;
 
 const getEcosystems = (apollo, pageSize, page) => {
@@ -192,6 +209,17 @@ const getProjectByName = (apollo, name, ecosystemId) => {
       }
     },
     fetchPolicy: "no-cache"
+  });
+  return response;
+};
+
+const getDatasetsByUri = (apollo, projectId, uri) => {
+  const response = apollo.query({
+    query: GET_DATASET_BY_URI,
+    variables: {
+      projectId: projectId,
+      uri: uri
+    }
   });
   return response;
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -151,6 +151,28 @@ const GET_PROJECT_BY_NAME = gql`
   ${datasetFragment}
 `;
 
+const GET_DATASET_BY_URI = gql`
+  query getDatasetsByUri($projectId: ID!, $uri: String!) {
+    datasets(filters: { uri: $uri, projectId: $projectId }) {
+      entities {
+        id
+        category
+        filters
+        datasource {
+          type {
+            name
+          }
+          uri
+        }
+        project {
+          ...projectFields
+        }
+      }
+    }
+  }
+  ${projectFragment}
+`;
+
 const getEcosystems = (apollo, pageSize, page) => {
   const response = apollo.query({
     query: GET_ECOSYSTEMS,
@@ -225,6 +247,7 @@ const getDatasetsByUri = (apollo, projectId, uri) => {
 };
 
 export {
+  getDatasetsByUri,
   getEcosystems,
   getEcosystemByID,
   getBasicProjectInfo,

--- a/ui/src/components/DatasetTable.stories.js
+++ b/ui/src/components/DatasetTable.stories.js
@@ -1,0 +1,48 @@
+import DatasetTable from "./DatasetTable";
+
+export default {
+  title: "DatasetTable",
+  excludeStories: /.*Data$/
+};
+
+const template = '<dataset-table :datasets="datasets" />';
+
+export const Default = () => ({
+  components: { DatasetTable },
+  template: template,
+  data() {
+    return {
+      datasets: [
+        {
+          datasource: {
+            type: {
+              name: "Git"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          filters: { branches: ["branch_1", "branch_2"] },
+          category: "commit"
+        },
+        {
+          datasource: {
+            type: {
+              name: "GitHub"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          category: "prs"
+        },
+        {
+          datasource: {
+            type: {
+              name: "GitHub"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          category: "issue",
+          filters: { tags: ["python", "bug"], from_date: "2021-01-01" }
+        }
+      ]
+    };
+  }
+});

--- a/ui/src/components/DatasetTable.vue
+++ b/ui/src/components/DatasetTable.vue
@@ -1,0 +1,98 @@
+<template>
+  <section>
+    <div class="d-flex justify-space-between mb-3">
+      <h3 class="text-h6 d-flex align-center">
+        Data sets
+        <v-chip small pill class="ml-2 info--text" color="info--background">
+          {{ datasets.length }}
+        </v-chip>
+      </h3>
+    </div>
+    <v-simple-table>
+      <template v-slot:default>
+        <thead>
+          <tr>
+            <th class="text-left">
+              Source
+            </th>
+            <th class="text-left">
+              Category
+            </th>
+            <th class="text-left">
+              Filters
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(item, i) in datasets" :key="i" class="table-row">
+            <td class="text-start">
+              <source-icon
+                :source="item.datasource.type.name"
+                color="rgba(0, 0, 0, 0.87)"
+                class="mr-2"
+                small
+              />
+              {{ item.datasource.type.name }}
+            </td>
+
+            <td>{{ item.category }}</td>
+
+            <td class="text-start pt-1 pb-1">
+              <p v-for="(value, key) in item.filters" :key="key" class="filter">
+                <span class="mr-1 font-weight-medium">{{ key }}:</span>
+                <v-chip
+                  v-if="typeof value === 'string'"
+                  label
+                  class="ma-0 mr-1"
+                  small
+                >
+                  <span>{{ value }}</span>
+                </v-chip>
+                <span v-else-if="typeof value === 'object'">
+                  <v-chip
+                    v-for="(val, index) in value"
+                    :key="index"
+                    label
+                    class="ma-0 mr-1"
+                    small
+                  >
+                    <span>{{ val.toString().replace("[]", "") }}</span>
+                  </v-chip>
+                </span>
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+  </section>
+</template>
+
+<script>
+import SourceIcon from "./SourceIcon";
+
+export default {
+  name: "DatasetTable",
+  components: { SourceIcon },
+  props: {
+    datasets: {
+      type: Array,
+      required: true
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.theme--light.v-data-table
+  > .v-data-table__wrapper
+  > table
+  > tbody
+  > .table-row:hover:not(.v-data-table__empty-wrapper) {
+  background: #f6fbff;
+}
+
+.filter:last-of-type {
+  margin-bottom: 0;
+}
+</style>

--- a/ui/src/components/DatasourceList.stories.js
+++ b/ui/src/components/DatasourceList.stories.js
@@ -1,0 +1,86 @@
+import DatasourceList from "./DatasourceList";
+
+export default {
+  title: "DatasourceList",
+  excludeStories: /.*Data$/
+};
+
+const template = '<datasource-list :items="items" project-id="1" />';
+
+export const Default = () => ({
+  components: { DatasourceList },
+  template: template,
+  data() {
+    return {
+      items: [
+        {
+          datasource: {
+            type: {
+              name: "github"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          category: "issue"
+        },
+        {
+          datasource: {
+            type: {
+              name: "github"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          category: "prs"
+        },
+        {
+          datasource: {
+            type: {
+              name: "github"
+            },
+            uri: "https://github.com/organization/repository-2"
+          },
+          filters: { tags: ["python", "bug"], from_date: "2021-01-01" },
+          category: "issue"
+        },
+        {
+          datasource: {
+            type: {
+              name: "git"
+            },
+            uri: "https://github.com/organization/repository-1"
+          },
+          category: "commit"
+        },
+        {
+          datasource: {
+            type: {
+              name: "git"
+            },
+            uri: "https://github.com/organization/repository-2"
+          },
+          filters: { branches: ["branch_1", "branch_2"] },
+          category: "commit"
+        },
+        {
+          datasource: {
+            type: {
+              name: "jira"
+            },
+            uri: "https://jira.organization.com"
+          },
+          filters: {},
+          category: "issue"
+        },
+        {
+          datasource: {
+            type: {
+              name: "twitter"
+            },
+            uri: "@organization"
+          },
+          filters: {},
+          category: "tweet"
+        }
+      ]
+    };
+  }
+});

--- a/ui/src/components/DatasourceList.vue
+++ b/ui/src/components/DatasourceList.vue
@@ -1,0 +1,96 @@
+<template>
+  <section>
+    <div class="d-flex justify-space-between">
+      <h3 class="text-h6 d-flex align-center">
+        Data sources
+        <v-chip small pill class="ml-2 info--text" color="info--background">
+          {{ count }}
+        </v-chip>
+      </h3>
+    </div>
+
+    <v-list>
+      <router-link
+        v-for="(value, uri) in list"
+        :key="uri"
+        :to="{
+          name: 'datasource',
+          params: {
+            id: projectId,
+            uri: uri
+          }
+        }"
+        custom
+        v-slot="{ href, route, navigate }"
+      >
+        <v-list-item :href="href" @click="navigate">
+          <v-list-item-content>
+            <v-list-item-title>
+              <span class="mr-4">{{ uri }}</span>
+              <v-chip
+                v-for="item in value"
+                :key="item.category"
+                class="mr-2"
+                outlined
+                small
+              >
+                <source-icon
+                  :source="item.datasource.type.name"
+                  class="mr-1"
+                  small
+                />
+                {{ item.category }}
+              </v-chip>
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </router-link>
+    </v-list>
+  </section>
+</template>
+
+<script>
+import SourceIcon from "./SourceIcon";
+
+export default {
+  name: "DatasourceList",
+  components: { SourceIcon },
+  props: {
+    items: {
+      type: Array,
+      required: true
+    },
+    projectId: {
+      type: [String, Number],
+      required: true
+    }
+  },
+  data() {
+    return {
+      list: []
+    };
+  },
+  computed: {
+    count() {
+      return Object.entries(this.list).length;
+    }
+  },
+  methods: {
+    groupByUri(sources) {
+      return sources.reduce((acc, current) => {
+        acc[current.datasource.uri] = acc[current.datasource.uri] || [];
+        acc[current.datasource.uri].push(current);
+        return acc;
+      }, {});
+    }
+  },
+  mounted() {
+    this.list = this.groupByUri(this.items);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+@import "../styles/_lists";
+</style>

--- a/ui/src/components/ProjectEntry.vue
+++ b/ui/src/components/ProjectEntry.vue
@@ -41,10 +41,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "../styles/_lists";
+
 ::v-deep .v-list-item__title span {
   font-weight: 500;
-}
-.v-list-item--link::before {
-  background-color: #003756;
 }
 </style>

--- a/ui/src/components/ProjectList.vue
+++ b/ui/src/components/ProjectList.vue
@@ -3,7 +3,9 @@
     <div class="d-flex justify-space-between">
       <h3 class="text-h6 d-flex align-center">
         Projects
-        <v-chip small pill class="ml-2">{{ list.length }}</v-chip>
+        <v-chip small pill class="ml-2 info--text" color="info--background">
+          {{ list.length }}
+        </v-chip>
       </h3>
       <v-btn
         class="primary--text button--lowercase"
@@ -94,14 +96,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "../styles/_buttons";
+@import "../styles/_lists";
+
 ::v-deep .v-list-item__title span {
   font-weight: 500;
-}
-.button--lowercase {
-  text-transform: none;
-  letter-spacing: normal;
-}
-.v-list-item:not(:last-child) {
-  border-bottom: thin solid rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/ui/src/components/SourceIcon.stories.js
+++ b/ui/src/components/SourceIcon.stories.js
@@ -1,0 +1,21 @@
+import SourceIcon from "./SourceIcon.vue";
+
+export default {
+  title: "SourceIcon",
+  excludeStories: /.*Data$/
+};
+
+export const Default = () => ({
+  components: { SourceIcon },
+  template: "<source-icon source='git' />"
+});
+
+export const Color = () => ({
+  components: { SourceIcon },
+  template: "<source-icon source='git' color='primary' />"
+});
+
+export const Small = () => ({
+  components: { SourceIcon },
+  template: "<source-icon source='git' small />"
+});

--- a/ui/src/components/SourceIcon.vue
+++ b/ui/src/components/SourceIcon.vue
@@ -1,9 +1,5 @@
 <template>
-  <v-icon
-    v-text="getIcon(source)"
-    :color="color"
-    :small="small"
-  />
+  <v-icon v-text="getIcon(source)" :color="color" :small="small" />
 </template>
 <script>
 export default {
@@ -49,5 +45,5 @@ export default {
       }
     }
   }
-}
+};
 </script>

--- a/ui/src/components/SourceIcon.vue
+++ b/ui/src/components/SourceIcon.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-icon
+    v-text="getIcon(source)"
+    :color="color"
+    :small="small"
+  />
+</template>
+<script>
+export default {
+  name: "SourceIcon",
+  props: {
+    source: {
+      type: String,
+      required: true
+    },
+    color: {
+      type: String,
+      required: false
+    },
+    small: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  methods: {
+    getIcon(source) {
+      const icons = [
+        { source: "git", icon: "mdi-git" },
+        { source: "github", icon: "mdi-github" },
+        { source: "gitlab", icon: "mdi-gitlab" },
+        { source: "dockerhub", icon: "mdi-docker" },
+        { source: "jira", icon: "mdi-jira" },
+        { source: "rss", icon: "mdi-rss" },
+        { source: "slack", icon: "mdi-slack" },
+        { source: "stackexchange", icon: "mdi-stack-exchange" },
+        { source: "telegram", icon: "mdi-telegram" },
+        { source: "twitter", icon: "mdi-twitter" }
+      ];
+
+      const sourceIcon = icons.find(
+        icon => icon.source === source.toLowerCase()
+      );
+
+      if (sourceIcon) {
+        return sourceIcon.icon;
+      } else {
+        return "";
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/plugins/vuetify.js
+++ b/ui/src/plugins/vuetify.js
@@ -11,7 +11,8 @@ const opts = {
     themes: {
       light: {
         primary: "#003756",
-        secondary: "#f4bc00"
+        secondary: "#f4bc00",
+        "info--background": "#e4f2fE"
       }
     }
   }

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -54,6 +54,12 @@ const router = new Router({
           path: "/search",
           component: () => import("../views/SearchResults"),
           meta: { requiresAuth: true }
+        },
+        {
+          name: "datasource",
+          path: "/project/:id/datasource/:uri",
+          component: () => import("../views/Datasource"),
+          meta: { requiresAuth: true }
         }
       ]
     },

--- a/ui/src/styles/_lists.scss
+++ b/ui/src/styles/_lists.scss
@@ -1,0 +1,9 @@
+@import '_variables';
+
+.v-list-item:not(:last-child) {
+  border-bottom: thin solid $border-color;
+}
+
+.v-list-item--link::before {
+  background-color: $info-color;
+}

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -1,3 +1,5 @@
 $primary-color: #003756;
 $text-color: #3f3f3f;
 $text-color--light: #7a7a7a;
+$border-color: rgba(0, 0, 0, 0.12);
+$info-color: #2196f3;

--- a/ui/src/views/Datasource.vue
+++ b/ui/src/views/Datasource.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="pa-5">
+    <breadcrumbs :items="breadcrumbs" />
+    <dataset-table :datasets="datasets" />
+  </div>
+</template>
+
+<script>
+import { getDatasetsByUri } from "../apollo/queries";
+import { getViewBreadCrumbs } from "../utils";
+import Breadcrumbs from "../components/Breadcrumbs";
+import DatasetTable from "../components/DatasetTable";
+
+export default {
+  name: "Datasource",
+  components: {
+    Breadcrumbs,
+    DatasetTable
+  },
+  data() {
+    return {
+      datasets: []
+    };
+  },
+  computed: {
+    projectId() {
+      return this.$route.params.id;
+    },
+    uri() {
+      return this.$route.params.uri;
+    },
+    breadcrumbs() {
+      if (this.datasets.length > 0) {
+        return getViewBreadCrumbs(
+          this.uri,
+          this.datasets[0].project.ecosystem,
+          this.datasets[0].project
+        );
+      } else {
+        return [];
+      }
+    }
+  },
+  methods: {
+    async getDatasets() {
+      try {
+        const response = await getDatasetsByUri(
+          this.$apollo,
+          this.projectId,
+          this.uri
+        );
+        this.datasets = response.data.datasets.entities;
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  },
+  mounted() {
+    this.getDatasets();
+  }
+};
+</script>

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -28,7 +28,10 @@
       :projects="project.subprojects"
       :ecosystem-id="ecosystemId"
       :parent-project="{ name: project.name, id: project.id }"
+      class="mb-9"
     />
+
+    <datasource-list :items="project.datasetSet" :project-id="project.id" />
   </div>
 </template>
 
@@ -38,10 +41,11 @@ import { deleteProject } from "../apollo/mutations";
 import { getProjectBreadcrumbs } from "../utils";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectList from "../components/ProjectList";
+import DatasourceList from "../components/DatasourceList";
 
 export default {
   name: "Project",
-  components: { Breadcrumbs, ProjectList },
+  components: { Breadcrumbs, ProjectList, DatasourceList },
   data() {
     return {
       project: null


### PR DESCRIPTION
This PR adds a list of data sources to the project's view, grouped by the source URI. Every data source on the list links to the `/project/id/datasource/uri` route, which expands its information. The `datasets` query is also updated to allow filtering by URI. 