### PR TITLE
[ui] Add GitHub repositories to projects

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -91,6 +91,31 @@ const TOKEN_AUTH = gql`
   }
 `;
 
+const ADD_DATASET = gql`
+  mutation addDataset(
+    $category: String
+    $datasourceName: String
+    $filters: JSONString
+    $projectId: ID!
+    $uri: String
+  ) {
+    addDataset(
+      category: $category
+      datasourceName: $datasourceName
+      filters: $filters
+      projectId: $projectId
+      uri: $uri
+    ) {
+      dataset {
+        id
+        datasource {
+          uri
+        }
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -180,6 +205,27 @@ const tokenAuth = (apollo, username, password) => {
   return response;
 };
 
+const addDataSet = (
+  apollo,
+  category,
+  datasourceName,
+  uri,
+  projectId,
+  filters
+) => {
+  const response = apollo.mutate({
+    mutation: ADD_DATASET,
+    variables: {
+      category: category,
+      datasourceName: datasourceName,
+      uri: uri,
+      projectId: projectId,
+      filters: JSON.stringify(filters)
+    }
+  });
+  return response;
+};
+
 export {
   addProject,
   deleteProject,
@@ -188,5 +234,6 @@ export {
   addEcosystem,
   updateEcosystem,
   deleteEcosystem,
-  tokenAuth
+  tokenAuth,
+  addDataSet
 };

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -116,6 +116,14 @@ const ADD_DATASET = gql`
   }
 `;
 
+const FETCH_GITHUB_OWNER_REPOS = gql`
+  mutation fetchGithubOwnerRepos($owner: String!, $apiToken: String) {
+    fetchGithubOwnerRepos(owner: $owner, apiToken: $apiToken) {
+      jobId
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -226,6 +234,17 @@ const addDataSet = (
   return response;
 };
 
+const fetchGithubOwnerRepos = (apollo, owner, apiToken) => {
+  const response = apollo.mutate({
+    mutation: FETCH_GITHUB_OWNER_REPOS,
+    variables: {
+      owner: owner,
+      apiToken: apiToken
+    }
+  });
+  return response;
+};
+
 export {
   addProject,
   deleteProject,
@@ -235,5 +254,6 @@ export {
   updateEcosystem,
   deleteEcosystem,
   tokenAuth,
-  addDataSet
+  addDataSet,
+  fetchGithubOwnerRepos
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -173,6 +173,24 @@ const GET_DATASET_BY_URI = gql`
   ${projectFragment}
 `;
 
+const GET_JOB = gql`
+  query getJob($jobId: String!) {
+    job(jobId: $jobId) {
+      status
+      result {
+        ... on GitHubRepoResultType {
+          url
+          fork
+          hasIssues
+        }
+      }
+      errors
+      jobId
+      jobType
+    }
+  }
+`;
+
 const getEcosystems = (apollo, pageSize, page) => {
   const response = apollo.query({
     query: GET_ECOSYSTEMS,
@@ -246,11 +264,23 @@ const getDatasetsByUri = (apollo, projectId, uri) => {
   return response;
 };
 
+const getJob = (apollo, jobId) => {
+  const response = apollo.query({
+    query: GET_JOB,
+    variables: {
+      jobId: jobId
+    }
+  });
+  return response;
+};
+
 export {
   getDatasetsByUri,
   getEcosystems,
   getEcosystemByID,
   getBasicProjectInfo,
   getProjects,
-  getProjectByName
+  getProjectByName,
+  getJob,
+  GET_JOB
 };

--- a/ui/src/components/EcosystemTree.stories.js
+++ b/ui/src/components/EcosystemTree.stories.js
@@ -11,6 +11,7 @@ const ecosystemTreeTemplate = `
     :delete-project="mockAction"
     :move-project="mockAction"
     :delete-ecosystem="mockAction"
+    :add-data-set="mockAction"
   />
 `;
 

--- a/ui/src/components/GitHubTable.stories.js
+++ b/ui/src/components/GitHubTable.stories.js
@@ -1,0 +1,120 @@
+import GitHubTable from "./GitHubTable.vue";
+
+export default {
+  title: "GitHubTable",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <git-hub-table
+    :items="items"
+    :get-projects="getProjects"
+    :add-data-set="addDataSet"
+    :show-loader="showLoader"
+  />
+`;
+
+export const Default = () => ({
+  components: { GitHubTable },
+  template: template,
+  data() {
+    return {
+      items: [
+        {
+          url: "https://github.com/organization/repository-1",
+          fork: false,
+          hasIssues: true
+        },
+        {
+          url: "https://github.com/organization/repository-2",
+          fork: false,
+          hasIssues: true
+        },
+        {
+          url: "https://github.com/organization/repository-3",
+          fork: true,
+          hasIssues: false
+        },
+        {
+          url: "https://github.com/organization/repository-4",
+          fork: false,
+          hasIssues: true
+        }
+      ],
+      projects: [
+        { name: "project-1" },
+        {
+          name: "subproject",
+          parentProject: {
+            name: "project-1"
+          }
+        },
+        { name: "project-2" }
+      ],
+      showLoader: false
+    };
+  },
+  methods: {
+    getProjects() {
+      return this.projects;
+    },
+    async addDataSet() {
+      await this.mockLoading();
+
+      return {};
+    },
+    mockLoading() {
+      return new Promise(resolve => setTimeout(resolve, 200));
+    }
+  }
+});
+
+export const Loading = () => ({
+  components: { GitHubTable },
+  template: template,
+  data() {
+    return {
+      items: [],
+      projects: [],
+      showLoader: true
+    };
+  },
+  methods: {
+    getProjects() {
+      return this.projects;
+    },
+    async addDataSet() {
+      await this.mockLoading();
+
+      return {};
+    },
+    mockLoading() {
+      return new Promise(resolve => setTimeout(resolve, 200));
+    }
+  }
+});
+
+export const NoResults = () => ({
+  components: { GitHubTable },
+  template: template,
+  data() {
+    return {
+      items: [],
+      projects: [],
+      showLoader: false
+    };
+  },
+  methods: {
+    getProjects() {
+      return this.projects;
+    },
+    async addDataSet() {
+      await this.mockLoading();
+
+      return {};
+    },
+    mockLoading() {
+      return new Promise(resolve => setTimeout(resolve, 200));
+    }
+  }
+});

--- a/ui/src/components/GitHubTable.vue
+++ b/ui/src/components/GitHubTable.vue
@@ -1,0 +1,354 @@
+<template>
+  <div>
+    <v-alert
+      v-if="error"
+      text
+      dense
+      dismissible
+      color="error"
+      icon="mdi-alert-circle-outline"
+      border="left"
+      class="mb-8"
+    >
+      {{ error }}
+    </v-alert>
+
+    <v-row
+      v-if="isLoading || repositories.length > 0"
+      class="mb-3 justify-space-between align-center flex-grow-0"
+    >
+      <v-switch
+        v-model="showForks"
+        label="Show forks"
+        color="info"
+        flat
+        dense
+        @change="filterForks($event)"
+      />
+
+      <v-menu
+        v-model="showMenu"
+        max-height="40vh"
+        offset-y
+        :close-on-content-click="false"
+      >
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            v-on="on"
+            :disabled="selected.length === 0"
+            color="info"
+            depressed
+            class="button--lowercase"
+            @click="loadProjects({ term: '' })"
+          >
+            Add selected to project
+            <v-icon right small>mdi-chevron-down</v-icon>
+          </v-btn>
+        </template>
+
+        <v-card class="pa-2 pt-0">
+          <search @search="loadProjects" class="search pt-2" filled />
+          <v-list dense class="pt-0">
+            <v-list-item
+              v-for="project in projects"
+              :key="project.id"
+              class="v-list-item--link"
+              @click="addDatasets(project)"
+            >
+              <v-list-item-content>
+                <v-list-item-subtitle v-html="project.path" />
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-menu>
+    </v-row>
+
+    <v-data-table
+      v-model="selected"
+      :headers="headers"
+      :items="repositories"
+      :loading="isLoading"
+      :hide-default-header="!isLoading && repositories.length === 0"
+      :hide-default-footer="!isLoading && repositories.length === 0"
+      item-key="url"
+      disable-sort
+      show-select
+    >
+      <template v-slot:item="{ item, isSelected, select }">
+        <tr
+          draggable
+          class="table-row"
+          :class="{ 'v-data-table__selected': isSelected }"
+          @dragstart="startDrag(item, isSelected, $event)"
+        >
+          <td>
+            <v-simple-checkbox
+              :value="isSelected"
+              :ripple="false"
+              @click="select(!isSelected)"
+            />
+          </td>
+          <td>
+            <span>{{ item.url }}</span>
+            <v-chip
+              small
+              v-if="item.fork"
+              class="ml-2"
+              color="info--background"
+              text-color="info"
+            >
+              <v-icon small left>mdi-source-fork</v-icon>
+              fork
+            </v-chip>
+          </td>
+          <td>
+            <v-simple-checkbox
+              v-model="item.form.commit"
+              :ripple="false"
+              color="info"
+            ></v-simple-checkbox>
+          </td>
+          <td>
+            <v-simple-checkbox
+              v-model="item.form.issue"
+              :disabled="item.disableIssues"
+              :ripple="false"
+              color="info"
+            ></v-simple-checkbox>
+          </td>
+          <td>
+            <v-simple-checkbox
+              v-model="item.form.pr"
+              :ripple="false"
+              color="info"
+            ></v-simple-checkbox>
+          </td>
+        </tr>
+      </template>
+      <template v-slot:progress>
+        <div class="d-flex justify-center mt-4 mb-2">
+          <v-progress-circular
+            :size="50"
+            color="primary"
+            indeterminate
+          ></v-progress-circular>
+        </div>
+      </template>
+      <template v-slot:no-data>
+        <div class="d-flex flex-column justify-center align-center mt-4">
+          <v-icon large>mdi-magnify-remove-outline</v-icon>
+          <p class="mt-4 text-body-1">No repositories found</p>
+        </div>
+      </template>
+    </v-data-table>
+
+    <v-card class="dragged-item" color="primary" dark>
+      <v-card-subtitle>
+        Add {{ selected.length }} datasets to a project
+      </v-card-subtitle>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import Search from "../components/Search";
+
+export default {
+  name: "GitHubTable",
+  components: { Search },
+  props: {
+    items: {
+      type: Array,
+      required: true
+    },
+    getProjects: {
+      type: Function,
+      required: true
+    },
+    addDataSet: {
+      type: Function,
+      required: true
+    },
+    showLoader: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  data() {
+    return {
+      headers: [
+        { text: "URL", value: "url" },
+        { text: "Commits", value: "commits" },
+        { text: "Issues", value: "issues" },
+        { text: "Pull Requests", value: "prs" }
+      ],
+      repositories: [],
+      selected: [],
+      projects: [],
+      showForks: true,
+      showMenu: false,
+      isLoading: this.showLoader,
+      error: null
+    };
+  },
+  methods: {
+    addFormValues(array) {
+      return array.map(item => {
+        return {
+          url: item.url,
+          fork: item.fork,
+          disableIssues: !item.hasIssues,
+          form: {
+            commit: true,
+            pr: true,
+            issue: item.hasIssues
+          }
+        };
+      });
+    },
+    filterForks(value) {
+      if (value) {
+        this.repositories = this.addFormValues(this.items);
+      } else {
+        this.repositories = this.addFormValues(this.items).filter(
+          item => !item.fork
+        );
+        this.selected = this.selected.filter(item => !item.fork);
+      }
+    },
+    startDrag(item, isSelected, event) {
+      if (!isSelected) {
+        this.selected.push(item);
+      }
+      event.dataTransfer.setData("type", "AddDatasources");
+      event.dataTransfer.setData(
+        "text/plain",
+        JSON.stringify(this.selectedByCategory)
+      );
+      const dragImage = document.querySelector(".dragged-item");
+      event.dataTransfer.setDragImage(dragImage, 0, 0);
+    },
+    async loadProjects(term) {
+      const response = await this.getProjects(term);
+      if (response) {
+        this.projects = response;
+        this.projects.forEach(res => {
+          Object.assign(res, { path: this.getPath(res) });
+        });
+      }
+    },
+    getPath(project) {
+      const path = [project.name];
+
+      function findParents(parent) {
+        if (parent) {
+          path.push(parent.name);
+          findParents(parent.parentProject);
+        }
+      }
+
+      findParents(project.parentProject);
+
+      return path
+        .reverse()
+        .toString()
+        .replace(/,/g, " / ");
+    },
+    async addDatasets(project) {
+      this.showMenu = false;
+      this.error = null;
+      let added = [];
+
+      try {
+        for (let selected of this.selectedByCategory) {
+          const mutation = await this.addDataSet(
+            selected.category,
+            "GitHub",
+            selected.url,
+            project.id
+          );
+          added.push(
+            Object.assign(mutation, {
+              project: project.id
+            })
+          );
+        }
+      } catch (error) {
+        this.error = error;
+      }
+
+      if (added.length !== 0) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: `Added ${added.length} datasets to ${project.title}`,
+          color: "success"
+        });
+      }
+    }
+  },
+  computed: {
+    selectedByCategory() {
+      return this.selected.reduce((list, current) => {
+        Object.entries(current.form).forEach(category => {
+          const [key, value] = category;
+          if (value) {
+            list.push({
+              category: key,
+              url: current.url
+            });
+          }
+        });
+        return list;
+      }, []);
+    }
+  },
+  watch: {
+    items(list) {
+      this.repositories = this.addFormValues(list);
+    },
+    showLoader(value) {
+      this.isLoading = value;
+    }
+  },
+  mounted() {
+    this.repositories = this.addFormValues(this.items);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+@import "../styles/_lists";
+@import "../styles/_tables";
+
+::v-deep
+  .theme--light.v-data-table
+  > .v-data-table__wrapper
+  > table
+  > tbody
+  > tr {
+  cursor: grab;
+}
+
+.dragged-item {
+  max-width: 300px;
+  position: absolute;
+  top: -300px;
+}
+
+.search {
+  position: sticky;
+  top: 0;
+  background-color: #ffffff;
+  z-index: 2;
+}
+
+.v-list-item__title,
+.v-list-item__subtitle {
+  text-overflow: unset;
+  white-space: break-spaces;
+}
+</style>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -60,6 +60,11 @@ const router = new Router({
           path: "/project/:id/datasource/:uri",
           component: () => import("../views/Datasource"),
           meta: { requiresAuth: true }
+        },
+        {
+          name: "github-datasources",
+          path: "/datasources/github/:jobID",
+          component: () => import("../views/GithubDatasources")
         }
       ]
     },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -62,6 +62,11 @@ const router = new Router({
           meta: { requiresAuth: true }
         },
         {
+          name: "add-datasources",
+          path: "/datasources",
+          component: () => import("../views/AddDatasources")
+        },
+        {
           name: "github-datasources",
           path: "/datasources/github/:jobID",
           component: () => import("../views/GithubDatasources")

--- a/ui/src/styles/_tables.scss
+++ b/ui/src/styles/_tables.scss
@@ -11,7 +11,6 @@
   }
 
   &:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper).v-data-table__selected {
-    // background: #ddf0ff;
     background: darken($selected-color, 5%);
   }
 }

--- a/ui/src/styles/_tables.scss
+++ b/ui/src/styles/_tables.scss
@@ -1,0 +1,17 @@
+@import '_variables';
+
+::v-deep .theme--light.v-data-table
+> .v-data-table__wrapper
+> table
+> tbody
+> tr {
+  &:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
+  &.v-data-table__selected {
+    background: $selected-color;
+  }
+
+  &:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper).v-data-table__selected {
+    // background: #ddf0ff;
+    background: darken($selected-color, 5%);
+  }
+}

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -3,3 +3,4 @@ $text-color: #3f3f3f;
 $text-color--light: #7a7a7a;
 $border-color: rgba(0, 0, 0, 0.12);
 $info-color: #2196f3;
+$selected-color: #f6fbff;

--- a/ui/src/views/AddDatasources.vue
+++ b/ui/src/views/AddDatasources.vue
@@ -1,0 +1,86 @@
+<template>
+  <section class="d-flex flex-column">
+    <h3 class="text-h6 mt-6 mb-4">
+      Add data sources
+    </h3>
+
+    <transition name="opacity">
+      <div v-if="isLoading" class="d-flex justify-center">
+        <v-progress-circular
+          :size="50"
+          color="primary"
+          indeterminate
+        ></v-progress-circular>
+      </div>
+    </transition>
+
+    <v-form v-if="!isLoading">
+      <p class="mt-3 mb-0 text--secondary">
+        Load all repositories from a GitHub user or organization. You will be
+        able to add all of their commits, pull requests and issues to the
+        project or review and select each one individually.
+      </p>
+      <v-row class="mt-2">
+        <v-col cols="4">
+          <v-text-field
+            v-model="owner"
+            label="GitHub owner"
+            outlined
+            dense
+            @keydown.enter.prevent="getGithubOwnerRepos"
+          />
+        </v-col>
+        <v-col>
+          <v-btn
+            :disabled="!owner"
+            color="info"
+            class="button--lowercase"
+            depressed
+            @click.prevent="getGithubOwnerRepos"
+          >
+            Load
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-form>
+  </section>
+</template>
+
+<script>
+import { fetchGithubOwnerRepos } from "../apollo/mutations";
+
+export default {
+  name: "AddDatasources",
+  data() {
+    return {
+      owner: "",
+      isLoading: false
+    };
+  },
+  methods: {
+    async getGithubOwnerRepos() {
+      this.isLoading = true;
+      const response = await fetchGithubOwnerRepos(this.$apollo, this.owner);
+      if (response.data.fetchGithubOwnerRepos.jobId) {
+        this.$router.push({
+          name: "github-datasources",
+          params: { jobID: response.data.fetchGithubOwnerRepos.jobId }
+        });
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.v-progress-circular {
+  margin-top: 130px;
+}
+.opacity-enter {
+  opacity: 0;
+
+  &-active {
+    transition: opacity 2.5s;
+  }
+}
+</style>

--- a/ui/src/views/GithubDatasources.vue
+++ b/ui/src/views/GithubDatasources.vue
@@ -1,0 +1,122 @@
+<template>
+  <section class="d-flex flex-column">
+    <h3 class="text-h6 mt-6 mb-4">
+      Add data sources
+    </h3>
+
+    <v-alert
+      v-if="error.length !== 0"
+      text
+      dense
+      color="error"
+      icon="mdi-alert-outline"
+      border="left"
+    >
+      {{ error }}
+    </v-alert>
+
+    <git-hub-table
+      :items="items"
+      :add-data-set="addDataSet"
+      :get-projects="getProjects"
+      :show-loader="isLoading"
+      class="pa-5"
+    />
+
+    <v-alert
+      v-if="!isLoading && items.length > 0"
+      text
+      dense
+      dismissible
+      color="info"
+      icon="mdi-lightbulb"
+      border="left"
+      class="mt-auto"
+    >
+      You can also add datasets by dragging and dropping them onto a project on
+      the sidebar menu
+    </v-alert>
+  </section>
+</template>
+
+<script>
+import { getProjects, GET_JOB } from "../apollo/queries";
+import { addDataSet } from "../apollo/mutations";
+import GitHubTable from "../components/GitHubTable";
+
+export default {
+  name: "GithubDatasources",
+  components: { GitHubTable },
+  data() {
+    return {
+      items: [],
+      error: "",
+      isLoading: true
+    };
+  },
+  computed: {
+    jobID() {
+      return this.$route.params.jobID;
+    }
+  },
+  methods: {
+    async getProjects(filters, pageSize = 50, page = 1) {
+      const response = await getProjects(this.$apollo, pageSize, page, filters);
+      if (response) {
+        return response.data.projects.entities;
+      }
+    },
+    async addDataSet(category, datasourceName, uri, projectId, filters = {}) {
+      const response = await addDataSet(
+        this.$apollo,
+        category,
+        datasourceName,
+        uri,
+        projectId,
+        filters
+      );
+      if (response) {
+        return response;
+      }
+    }
+  },
+  mounted() {
+    // Run the 'job' query every second
+    this.$apollo.queries.job.startPolling(1000);
+  },
+  apollo: {
+    job: {
+      query: GET_JOB,
+      variables() {
+        return {
+          jobId: this.jobID
+        };
+      },
+      result(result) {
+        // Stop running the query if its status is 'finished'
+        if (result.data && result.data.job.status === "finished") {
+          this.$apollo.queries.job.stopPolling();
+          this.items = result.data.job.result;
+          this.error = "";
+          this.isLoading = false;
+
+          if (result.data.job.errors) {
+            this.error = result.data.job.errors;
+          }
+        }
+      },
+      error(error) {
+        this.$apollo.queries.job.stopPolling();
+        this.error = error;
+        this.isLoading = false;
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+section {
+  min-height: 95vh;
+}
+</style>

--- a/ui/src/views/Sidebar.vue
+++ b/ui/src/views/Sidebar.vue
@@ -2,12 +2,14 @@
   <v-app>
     <v-navigation-drawer permanent app class="pa-3" color="#F5F7F8">
       <search class="mt-4" filled @search="search" ref="search" />
+      <h2 class="text-subtitle-1 ma-2">Ecosystems</h2>
       <div v-for="ecosystem in ecosystems" :key="ecosystem.id">
         <ecosystem-tree
           :ecosystem="ecosystem"
           :delete-project="deleteProject"
           :move-project="moveProject"
           :delete-ecosystem="deleteEcosystem"
+          :add-data-set="addDataSet"
         />
       </div>
       <v-btn
@@ -19,6 +21,18 @@
       >
         <v-icon small class="mr-1">mdi-plus</v-icon>
         Add ecosystem
+      </v-btn>
+      <v-divider class="mt-3 mb-3" />
+      <h2 class="text-subtitle-1 text--secondary ma-2">Data sources</h2>
+      <v-btn
+        :to="{ name: 'add-datasources' }"
+        class="link pl-2"
+        color="#3f3f3f"
+        text
+        block
+      >
+        <v-icon small class="mr-1">mdi-plus</v-icon>
+        Add data sources
       </v-btn>
       <template v-slot:append>
         <v-divider />
@@ -39,6 +53,7 @@
         </div>
       </template>
     </v-navigation-drawer>
+
     <v-main>
       <v-container>
         <transition name="fade" mode="out-in">
@@ -58,7 +73,11 @@
       :width="dialog.width"
     >
     </simple-dialog>
-    <v-snackbar v-model="snackbar.isOpen" :color="snackbar.color">
+    <v-snackbar
+      v-model="snackbar.isOpen"
+      :color="snackbar.color"
+      timeout="8000"
+    >
       {{ snackbar.text }}
     </v-snackbar>
   </v-app>
@@ -69,7 +88,8 @@ import { getEcosystems } from "../apollo/queries";
 import {
   deleteProject,
   moveProject,
-  deleteEcosystem
+  deleteEcosystem,
+  addDataSet
 } from "../apollo/mutations";
 import { mapGetters, mapActions } from "vuex";
 import EcosystemTree from "../components/EcosystemTree";
@@ -158,6 +178,17 @@ export default {
           color: "error"
         });
       }
+    },
+    async addDataSet(category, datasourceName, uri, projectId, filters = {}) {
+      const response = await addDataSet(
+        this.$apollo,
+        category,
+        datasourceName,
+        uri,
+        projectId,
+        filters
+      );
+      return response;
     }
   },
   created() {
@@ -204,5 +235,9 @@ export default {
   .v-btn__content {
     color: #003756;
   }
+}
+
+.text-subtitle-1 {
+  color: #7a7a7a;
 }
 </style>

--- a/ui/tests/unit/EcosystemTree.spec.js
+++ b/ui/tests/unit/EcosystemTree.spec.js
@@ -64,7 +64,8 @@ describe("EcosystemTree", () => {
         ecosystem: threeLevels,
         deleteProject: () => {},
         moveProject: () => {},
-        deleteEcosystem: () => {}
+        deleteEcosystem: () => {},
+        addDataSet: () => {}
       },
       ...options
     });

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -204,7 +204,8 @@ describe("Ecosystem mutations", () => {
         },
         deleteEcosystem: mutate,
         deleteProject: () => {},
-        moveProject: () => {}
+        moveProject: () => {},
+        addDataSet: () => {}
       }
     });
 


### PR DESCRIPTION
This PR adds a view at `/datasets` with a form to get the GitHub repositories from a given owner. On submit, it calls the `githubOwnerRepos` mutation and redirects to `/datasources/github/id` using the resulting job ID. The `job` query is then performed every second until it returns the `finished` status.
Users can select commits, PRs and issues for each repository and add them to a project by selecting it from a dropdown menu or dragging and dropping them from the table to the sidebar.

Note: the PR needs the GraphQL mutations from #93 in order to work properly.