### PR TITLE
[ui] Remove datasets from a project

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -116,6 +116,16 @@ const ADD_DATASET = gql`
   }
 `;
 
+const DELETE_DATASET = gql`
+  mutation deleteDataset($id: ID!) {
+    deleteDataset(id: $id) {
+      dataset {
+        id
+      }
+    }
+  }
+`;
+
 const FETCH_GITHUB_OWNER_REPOS = gql`
   mutation fetchGithubOwnerRepos($owner: String!, $apiToken: String) {
     fetchGithubOwnerRepos(owner: $owner, apiToken: $apiToken) {
@@ -245,6 +255,16 @@ const fetchGithubOwnerRepos = (apollo, owner, apiToken) => {
   return response;
 };
 
+const deleteDataset = (apollo, id) => {
+  const response = apollo.mutate({
+    mutation: DELETE_DATASET,
+    variables: {
+      id: id
+    }
+  });
+  return response;
+};
+
 export {
   addProject,
   deleteProject,
@@ -255,5 +275,6 @@ export {
   deleteEcosystem,
   tokenAuth,
   addDataSet,
+  deleteDataset,
   fetchGithubOwnerRepos
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -32,6 +32,7 @@ const datasetFragment = gql`
       }
       uri
     }
+    id
     filters
     category
   }
@@ -259,7 +260,8 @@ const getDatasetsByUri = (apollo, projectId, uri) => {
     variables: {
       projectId: projectId,
       uri: uri
-    }
+    },
+    fetchPolicy: "no-cache"
   });
   return response;
 };

--- a/ui/src/components/DatasetTable.stories.js
+++ b/ui/src/components/DatasetTable.stories.js
@@ -5,7 +5,8 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const template = '<dataset-table :datasets="datasets" />';
+const template =
+  '<dataset-table :datasets="datasets" :delete-dataset="mockFunction" />';
 
 export const Default = () => ({
   components: { DatasetTable },
@@ -44,5 +45,8 @@ export const Default = () => ({
         }
       ]
     };
+  },
+  methods: {
+    mockFunction() {}
   }
 });

--- a/ui/src/components/DatasetTable.vue
+++ b/ui/src/components/DatasetTable.vue
@@ -21,6 +21,9 @@
             <th class="text-left">
               Filters
             </th>
+            <th class="text-right">
+              Actions
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -61,6 +64,14 @@
                 </span>
               </p>
             </td>
+
+            <td class="text-right">
+              <v-btn icon color="text" @click="confirmDelete(item)">
+                <v-icon small>
+                  mdi-trash-can-outline
+                </v-icon>
+              </v-btn>
+            </td>
           </tr>
         </tbody>
       </template>
@@ -78,6 +89,39 @@ export default {
     datasets: {
       type: Array,
       required: true
+    },
+    deleteDataset: {
+      type: Function,
+      required: true
+    }
+  },
+  methods: {
+    confirmDelete(item) {
+      const dialog = {
+        isOpen: true,
+        title: `Remove ${item.datasource.type.name} ${item.category}?`,
+        action: () => this.removeDataset(item)
+      };
+      this.$store.commit("setDialog", dialog);
+    },
+    async removeDataset(dataset) {
+      try {
+        await this.deleteDataset(dataset.id);
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: "Data set removed successfully",
+          color: "success"
+        });
+      } catch (error) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      } finally {
+        this.$store.commit("clearDialog");
+        this.$emit("updateDatasets");
+      }
     }
   }
 };

--- a/ui/src/components/DatasourceList.stories.js
+++ b/ui/src/components/DatasourceList.stories.js
@@ -5,7 +5,8 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const template = '<datasource-list :items="items" project-id="1" />';
+const template =
+  '<datasource-list :items="items" project-id="1" :deleteDataset="mockFunction" />';
 
 export const Default = () => ({
   components: { DatasourceList },
@@ -82,5 +83,8 @@ export const Default = () => ({
         }
       ]
     };
+  },
+  methods: {
+    mockFunction() {}
   }
 });

--- a/ui/src/components/SimpleDialog.vue
+++ b/ui/src/components/SimpleDialog.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-dialog v-model="isOpen" :max-width="width">
+  <v-dialog
+    v-model="isOpen"
+    :max-width="width"
+    @click:outside="$store.commit('clearDialog')"
+  >
     <v-card>
       <v-card-title class="headline">{{ title }}</v-card-title>
       <v-card-text>{{ text }}</v-card-text>

--- a/ui/src/components/SimpleDialog.vue
+++ b/ui/src/components/SimpleDialog.vue
@@ -55,7 +55,7 @@ export default {
     width: {
       type: [String, Number],
       required: false,
-      default: 400
+      default: 500
     }
   }
 };

--- a/ui/src/views/Datasource.vue
+++ b/ui/src/views/Datasource.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="pa-5">
     <breadcrumbs :items="breadcrumbs" />
-    <dataset-table :datasets="datasets" />
+    <dataset-table
+      :datasets="datasets"
+      :delete-dataset="deleteDataset"
+      @updateDatasets="getDatasets"
+    />
   </div>
 </template>
 
 <script>
 import { getDatasetsByUri } from "../apollo/queries";
+import { deleteDataset } from "../apollo/mutations";
 import { getViewBreadCrumbs } from "../utils";
 import Breadcrumbs from "../components/Breadcrumbs";
 import DatasetTable from "../components/DatasetTable";
@@ -19,7 +24,9 @@ export default {
   },
   data() {
     return {
-      datasets: []
+      datasets: [],
+      ecosystemId: null,
+      projectName: null
     };
   },
   computed: {
@@ -50,9 +57,25 @@ export default {
           this.uri
         );
         this.datasets = response.data.datasets.entities;
+        if (this.datasets.length > 0) {
+          this.ecosystemId = this.datasets[0].project.ecosystem.id;
+          this.projectName = this.datasets[0].project.name;
+        } else if (this.ecosystemId) {
+          this.$router.push({
+            name: "project",
+            params: {
+              ecosystemId: this.ecosystemId,
+              name: this.projectName
+            }
+          });
+        }
       } catch (error) {
         console.error(error);
       }
+    },
+    async deleteDataset(id) {
+      const response = await deleteDataset(this.$apollo, id);
+      return response;
     }
   },
   mounted() {

--- a/ui/src/views/Project.vue
+++ b/ui/src/views/Project.vue
@@ -36,13 +36,18 @@
       class="mb-9"
     />
 
-    <datasource-list :items="project.datasetSet" :project-id="project.id" />
+    <datasource-list
+      :items="project.datasetSet"
+      :project-id="project.id"
+      :delete-dataset="deleteDataset"
+      @updateDatasets="getProject"
+    />
   </div>
 </template>
 
 <script>
 import { getProjectByName } from "../apollo/queries";
-import { deleteProject } from "../apollo/mutations";
+import { deleteProject, deleteDataset } from "../apollo/mutations";
 import { getProjectBreadcrumbs } from "../utils";
 import Breadcrumbs from "../components/Breadcrumbs";
 import ProjectList from "../components/ProjectList";
@@ -108,6 +113,10 @@ export default {
           color: "error"
         });
       }
+    },
+    async deleteDataset(id) {
+      const response = await deleteDataset(this.$apollo, id);
+      return response;
     }
   },
   mounted() {


### PR DESCRIPTION
This PR adds the option to delete all of a project's datasets that share a URI on the `DatasourceList` component at the project view `/ecosystem/id/project/name`, or delete one specific dataset from the `DatasetTable` on the datasource view `/project/id/datasource/uri`.

Closes #96.