### PR TITLE
[ui] Manage credentials

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -135,8 +135,22 @@ const FETCH_GITHUB_OWNER_REPOS = gql`
 `;
 
 const ADD_CREDENTIAL = gql`
-  mutation addCredential($datasourceName: String!, $token: String!) {
-    addCredential(datasourceName: $datasourceName, token: $token) {
+  mutation addCredential(
+    $datasourceName: String!
+    $token: String!
+    $name: String!
+  ) {
+    addCredential(datasourceName: $datasourceName, token: $token, name: $name) {
+      credential {
+        id
+      }
+    }
+  }
+`;
+
+const DELETE_CREDENTIAL = gql`
+  mutation deleteCredential($id: ID!) {
+    deleteCredential(id: $id) {
       credential {
         id
       }
@@ -274,12 +288,23 @@ const deleteDataset = (apollo, id) => {
   return response;
 };
 
-const addCredential = (apollo, datasourceName, token) => {
+const addCredential = (apollo, datasourceName, token, name) => {
   const response = apollo.mutate({
     mutation: ADD_CREDENTIAL,
     variables: {
       datasourceName: datasourceName,
-      token: token
+      token: token,
+      name: name
+    }
+  });
+  return response;
+};
+
+const deleteCredential = (apollo, id) => {
+  const response = apollo.mutate({
+    mutation: DELETE_CREDENTIAL,
+    variables: {
+      id: id
     }
   });
   return response;
@@ -297,5 +322,6 @@ export {
   addDataSet,
   deleteDataset,
   fetchGithubOwnerRepos,
-  addCredential
+  addCredential,
+  deleteCredential
 };

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -134,6 +134,16 @@ const FETCH_GITHUB_OWNER_REPOS = gql`
   }
 `;
 
+const ADD_CREDENTIAL = gql`
+  mutation addCredential($datasourceName: String!, $token: String!) {
+    addCredential(datasourceName: $datasourceName, token: $token) {
+      credential {
+        id
+      }
+    }
+  }
+`;
+
 const addProject = (apollo, data) => {
   const response = apollo.mutate({
     mutation: ADD_PROJECT,
@@ -264,6 +274,17 @@ const deleteDataset = (apollo, id) => {
   return response;
 };
 
+const addCredential = (apollo, datasourceName, token) => {
+  const response = apollo.mutate({
+    mutation: ADD_CREDENTIAL,
+    variables: {
+      datasourceName: datasourceName,
+      token: token
+    }
+  });
+  return response;
+};
+
 export {
   addProject,
   deleteProject,
@@ -275,5 +296,6 @@ export {
   tokenAuth,
   addDataSet,
   deleteDataset,
-  fetchGithubOwnerRepos
+  fetchGithubOwnerRepos,
+  addCredential
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -193,10 +193,31 @@ const GET_JOB = gql`
 `;
 
 const GET_DATASOURCE_CREDENTIALS = gql`
-  query getDatasourceCredentials($datasource: String!) {
+  query getDatasourceCredentials($datasource: ID) {
     credentials(filters: { datasourceName: $datasource }) {
       entities {
         token
+      }
+    }
+  }
+`;
+
+const GET_USER_CREDENTIALS = gql`
+  query getUserCredentials($page: Int, $pageSize: Int) {
+    credentials(page: $page, pageSize: $pageSize) {
+      entities {
+        createdAt
+        id
+        name
+        datasource {
+          name
+        }
+      }
+      pageInfo {
+        page
+        pageSize
+        numPages
+        totalResults
       }
     }
   }
@@ -291,7 +312,20 @@ const getDatasourceCredentials = (apollo, datasource) => {
     query: GET_DATASOURCE_CREDENTIALS,
     variables: {
       datasource: datasource
-    }
+    },
+    fetchPolicy: "no-cache"
+  });
+  return response;
+};
+
+const getUserCredentials = (apollo, page, pageSize) => {
+  const response = apollo.query({
+    query: GET_USER_CREDENTIALS,
+    variables: {
+      pageSize,
+      page
+    },
+    fetchPolicy: "no-cache"
   });
   return response;
 };
@@ -305,5 +339,6 @@ export {
   getProjectByName,
   getJob,
   GET_JOB,
-  getDatasourceCredentials
+  getDatasourceCredentials,
+  getUserCredentials
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -192,6 +192,16 @@ const GET_JOB = gql`
   }
 `;
 
+const GET_DATASOURCE_CREDENTIALS = gql`
+  query getDatasourceCredentials($datasource: String!) {
+    credentials(filters: { datasourceName: $datasource }) {
+      entities {
+        token
+      }
+    }
+  }
+`;
+
 const getEcosystems = (apollo, pageSize, page) => {
   const response = apollo.query({
     query: GET_ECOSYSTEMS,
@@ -276,6 +286,16 @@ const getJob = (apollo, jobId) => {
   return response;
 };
 
+const getDatasourceCredentials = (apollo, datasource) => {
+  const response = apollo.query({
+    query: GET_DATASOURCE_CREDENTIALS,
+    variables: {
+      datasource: datasource
+    }
+  });
+  return response;
+};
+
 export {
   getDatasetsByUri,
   getEcosystems,
@@ -284,5 +304,6 @@ export {
   getProjects,
   getProjectByName,
   getJob,
-  GET_JOB
+  GET_JOB,
+  getDatasourceCredentials
 };

--- a/ui/src/components/CredentialsTable.stories.js
+++ b/ui/src/components/CredentialsTable.stories.js
@@ -1,0 +1,91 @@
+import CredentialsTable from "./CredentialsTable";
+
+export default {
+  title: "CredentialsTable",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <credentials-table
+    :fetch-credentials="fetchCredentials"
+    :delete-credential="deleteCredential"
+  />
+`;
+
+export const Default = () => ({
+  components: { CredentialsTable },
+  template: template,
+  data() {
+    return {
+      response: {
+        data: {
+          credentials: {
+            entities: [
+              {
+                createdAt: "2021-09-14T07:34:41.375401+00:00",
+                name: "Personal access token",
+                datasource: {
+                  name: "GitHub"
+                }
+              },
+              {
+                createdAt: "2021-07-01T12:38:58.375401+00:00",
+                name: "OAuth",
+                datasource: {
+                  name: "GitHub"
+                }
+              },
+              {
+                createdAt: "2020-01-08T09:45:00.375401+00:00",
+                name: "Read-only token",
+                datasource: {
+                  name: "GitLab"
+                }
+              }
+            ],
+            pageInfo: {
+              totalResults: 3,
+              numPages: 1
+            }
+          }
+        }
+      }
+    };
+  },
+  methods: {
+    fetchCredentials() {
+      return this.response;
+    },
+    deleteCredential() {
+      return;
+    }
+  }
+});
+
+export const Empty = () => ({
+  components: { CredentialsTable },
+  template: template,
+  data() {
+    return {
+      response: {
+        data: {
+          credentials: {
+            entities: [],
+            pageInfo: {
+              totalResults: 0,
+              numPages: 1
+            }
+          }
+        }
+      }
+    };
+  },
+  methods: {
+    fetchCredentials() {
+      return this.response;
+    },
+    deleteCredential() {
+      return;
+    }
+  }
+});

--- a/ui/src/components/CredentialsTable.vue
+++ b/ui/src/components/CredentialsTable.vue
@@ -1,0 +1,143 @@
+<template>
+  <section>
+    <h3 class="text-h6 d-flex align-center mt-8 mb-6">
+      Credentials
+      <v-chip small pill class="ml-2 info--text" color="info--background">
+        {{ totalResults }}
+      </v-chip>
+      <v-btn
+        class="button--lowercase button--secondary ml-auto"
+        :to="{ name: 'credentials-new' }"
+        outlined
+      >
+        <v-icon dense left>mdi-plus</v-icon>
+        Add credentials
+      </v-btn>
+    </h3>
+    <v-data-table
+      :headers="headers"
+      :items="credentials"
+      :items-per-page="pageSize"
+      :page.sync="page"
+      item-key="name"
+      sort-by="createdAt"
+      hide-default-footer
+      :hide-default-header="totalResults === 0"
+    >
+      <template v-slot:item.datasource.name="{ item }">
+        <source-icon
+          :source="item.datasource.name"
+          color="text"
+          class="mr-2 mb-1"
+          small
+        />
+        {{ item.datasource.name }}
+      </template>
+      <template v-slot:item.createdAt="{ item }">
+        <span class="text--secondary">
+          {{ new Date(item.createdAt).toLocaleString() }}
+        </span>
+      </template>
+      <template v-slot:item.actions="{ item }">
+        <v-btn icon color="text" @click="confirmDelete(item)">
+          <v-icon small>
+            mdi-trash-can-outline
+          </v-icon>
+        </v-btn>
+      </template>
+      <template v-slot:no-data>
+        <v-alert text dense color="warning" border="left">
+          This user has no access tokens saved.
+          <router-link :to="{ name: 'credentials-new' }">
+            Add a token
+          </router-link>
+        </v-alert>
+      </template>
+    </v-data-table>
+    <v-pagination
+      v-if="pages !== 1"
+      v-model="page"
+      :length="pages"
+      class="mt-6"
+      @input="getCredentials($event)"
+    ></v-pagination>
+  </section>
+</template>
+
+<script>
+import SourceIcon from "./SourceIcon";
+
+export default {
+  name: "CredentialsTable",
+  components: { SourceIcon },
+  props: {
+    fetchCredentials: {
+      type: Function,
+      required: true
+    },
+    deleteCredential: {
+      type: Function,
+      required: true
+    }
+  },
+  data() {
+    return {
+      credentials: [],
+      page: 1,
+      pageSize: 20,
+      pages: 1,
+      totalResults: 0,
+      headers: [
+        { text: "Data source", value: "datasource.name" },
+        { text: "Name", value: "name" },
+        { text: "Date added", value: "createdAt" },
+        { text: "", value: "actions" }
+      ]
+    };
+  },
+  methods: {
+    async getCredentials(page = this.page, pageSize = this.pageSize) {
+      const response = await this.fetchCredentials(page, pageSize);
+      this.credentials = response.data.credentials.entities;
+      this.totalResults = response.data.credentials.pageInfo.totalResults;
+      this.pages = response.data.credentials.pageInfo.numPages;
+    },
+    confirmDelete(item) {
+      const dialog = {
+        isOpen: true,
+        title: `Remove ${item.datasource.name} token "${item.name}"?`,
+        action: () => this.removeCredential(item.id)
+      };
+      this.$store.commit("setDialog", dialog);
+    },
+    async removeCredential(id) {
+      this.$store.commit("clearDialog");
+      try {
+        const response = await this.deleteCredential(id);
+        if (!response.errors) {
+          this.getCredentials();
+          this.$store.commit("setSnackbar", {
+            isOpen: true,
+            text: "Token removed successfully",
+            color: "success"
+          });
+        }
+      } catch (error) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+    }
+  },
+  created() {
+    this.getCredentials();
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+@import "../styles/_tables";
+</style>

--- a/ui/src/components/GithubForm.stories.js
+++ b/ui/src/components/GithubForm.stories.js
@@ -8,8 +8,10 @@ export default {
 const template = `
   <github-form
     :get-projects="getProjects"
-    :add-data-set="addDataSet"
-    :get-repos="addDataSet"
+    :add-data-set="mockAction"
+    :get-repos="mockAction"
+    :get-token="getToken"
+    :add-token="mockAction"
   />
 `;
 
@@ -36,8 +38,55 @@ export const Default = () => ({
         filters.term ? project.name.includes(filters.term) : true
       );
     },
-    addDataSet() {
+    mockAction() {
       return;
+    },
+    getToken() {
+      return {
+        data: {
+          credentials: {
+            entities: [{ token: "Example token" }]
+          }
+        }
+      };
+    }
+  }
+});
+
+export const NoToken = () => ({
+  components: { GithubForm },
+  template: template,
+  data() {
+    return {
+      projects: [
+        { name: "project-1" },
+        {
+          name: "subproject",
+          parentProject: {
+            name: "project-1"
+          }
+        },
+        { name: "project-2" }
+      ]
+    };
+  },
+  methods: {
+    getProjects(filters) {
+      return this.projects.filter(project =>
+        filters.term ? project.name.includes(filters.term) : true
+      );
+    },
+    mockAction() {
+      return;
+    },
+    getToken() {
+      return {
+        data: {
+          credentials: {
+            entities: []
+          }
+        }
+      };
     }
   }
 });

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -70,6 +70,11 @@ const router = new Router({
           name: "github-datasources",
           path: "/datasources/github/:jobID",
           component: () => import("../views/GithubDatasources")
+        },
+        {
+          name: "credentials-new",
+          path: "/credentials/new",
+          component: () => import("../views/AddCredentials")
         }
       ]
     },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -72,6 +72,11 @@ const router = new Router({
           component: () => import("../views/GithubDatasources")
         },
         {
+          name: "credentials",
+          path: "/credentials",
+          component: () => import("../views/Credentials")
+        },
+        {
           name: "credentials-new",
           path: "/credentials/new",
           component: () => import("../views/AddCredentials")

--- a/ui/src/views/AddCredentials.vue
+++ b/ui/src/views/AddCredentials.vue
@@ -1,0 +1,93 @@
+<template>
+  <section>
+    <h3 class="text-h6 mt-8 mb-6">Add credentials</h3>
+    <v-form>
+      <v-row class="mt-4 pb-4">
+        <v-col cols="4">
+          <v-select
+            v-model="datasource"
+            :items="sources"
+            label="Data source"
+            color="info"
+            hide-details
+            outlined
+            dense
+          ></v-select>
+        </v-col>
+      </v-row>
+      <v-row class="mt-4 pb-4">
+        <v-col cols="4">
+          <v-text-field
+            v-model="token"
+            label="Token"
+            color="info"
+            hide-details
+            outlined
+            dense
+          />
+        </v-col>
+      </v-row>
+      <v-row class="mt-4">
+        <v-col cols="4">
+          <v-text-field
+            v-model="name"
+            label="Name"
+            color="info"
+            hide-details
+            outlined
+            dense
+          />
+        </v-col>
+      </v-row>
+      <v-btn
+        :disabled="!datasource || !token || !name"
+        color="info"
+        class="button--lowercase mt-8"
+        depressed
+        @click.prevent="addToken"
+      >
+        Save
+      </v-btn>
+    </v-form>
+  </section>
+</template>
+
+<script>
+import { addCredential } from "../apollo/mutations";
+export default {
+  name: "AddCredentials",
+  data() {
+    return {
+      sources: ["GitHub"],
+      datasource: null,
+      token: "",
+      name: ""
+    };
+  },
+  methods: {
+    async addToken() {
+      try {
+        const response = await addCredential(
+          this.$apollo,
+          this.datasource,
+          this.token,
+          this.name
+        );
+        if (!response.errors) {
+          this.$router.push({ name: "credentials" });
+        }
+      } catch (error) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+</style>

--- a/ui/src/views/AddDatasources.vue
+++ b/ui/src/views/AddDatasources.vue
@@ -21,15 +21,22 @@
           v-else
           :get-projects="getProjects"
           :add-data-set="addDataSet"
-          :get-repos="getGithubOwnerRepos" />
+          :get-repos="getGithubOwnerRepos"
+          :get-token="getToken"
+          :add-token="addToken"
+        />
       </v-tab-item>
     </v-tabs>
   </section>
 </template>
 
 <script>
-import { getProjects } from "../apollo/queries";
-import { addDataSet, fetchGithubOwnerRepos } from "../apollo/mutations";
+import { getProjects, getDatasourceCredentials } from "../apollo/queries";
+import {
+  addDataSet,
+  addCredential,
+  fetchGithubOwnerRepos
+} from "../apollo/mutations";
 import GithubForm from "../components/GithubForm";
 
 export default {
@@ -69,6 +76,19 @@ export default {
           params: { jobID: response.data.fetchGithubOwnerRepos.jobId }
         });
       }
+    },
+    async getToken(datasource) {
+      const response = await getDatasourceCredentials(this.$apollo, datasource);
+      return response;
+    },
+    async addToken(datasource, token, name) {
+      const response = await addCredential(
+        this.$apollo,
+        datasource,
+        token,
+        name
+      );
+      return response;
     }
   }
 };

--- a/ui/src/views/Credentials.vue
+++ b/ui/src/views/Credentials.vue
@@ -1,0 +1,29 @@
+<template>
+  <section>
+    <credentials-table
+      :fetch-credentials="getCredentials"
+      :delete-credential="removeCredential"
+    />
+  </section>
+</template>
+
+<script>
+import { getUserCredentials } from "../apollo/queries";
+import { deleteCredential } from "../apollo/mutations";
+import CredentialsTable from "../components/CredentialsTable";
+
+export default {
+  name: "Credentials",
+  components: { CredentialsTable },
+  methods: {
+    async getCredentials(page = this.page, pageSize = this.pageSize) {
+      const response = await getUserCredentials(this.$apollo, page, pageSize);
+      return response;
+    },
+    async removeCredential(id) {
+      const response = await deleteCredential(this.$apollo, id);
+      return response;
+    }
+  }
+};
+</script>

--- a/ui/src/views/Sidebar.vue
+++ b/ui/src/views/Sidebar.vue
@@ -31,8 +31,16 @@
         text
         block
       >
-        <v-icon small class="mr-1">mdi-plus</v-icon>
         Add data sources
+      </v-btn>
+      <v-btn
+        :to="{ name: 'credentials' }"
+        class="link pl-2"
+        color="text"
+        text
+        block
+      >
+        Credentials
       </v-btn>
       <template v-slot:append>
         <v-divider />


### PR DESCRIPTION
This PR adds a view at `/credentials` to manage and delete the user's access tokens for the different data sources (only GitHub for now), and another at `/credentials/new` to save those tokens. If the user hasn't saved any GitHub tokens, it also shows an optional field to add one at `/datasources`.