### PR TITLE
[ui] Add GitLab repositories to a project

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -156,6 +156,14 @@ const FETCH_GITHUB_OWNER_REPOS = gql`
   }
 `;
 
+const FETCH_GITLAB_OWNER_REPOS = gql`
+  mutation fetchGitlabOwnerRepos($owner: String!) {
+    fetchGitlabOwnerRepos(owner: $owner) {
+      jobId
+    }
+  }
+`;
+
 const ADD_CREDENTIAL = gql`
   mutation addCredential(
     $datasourceName: String!
@@ -300,6 +308,16 @@ const fetchGithubOwnerRepos = (apollo, owner) => {
   return response;
 };
 
+const fetchGitlabOwnerRepos = (apollo, owner) => {
+  const response = apollo.mutate({
+    mutation: FETCH_GITLAB_OWNER_REPOS,
+    variables: {
+      owner: owner
+    }
+  });
+  return response;
+};
+
 const deleteDataset = (apollo, id) => {
   const response = apollo.mutate({
     mutation: DELETE_DATASET,
@@ -364,6 +382,7 @@ export {
   addDataSet,
   deleteDataset,
   fetchGithubOwnerRepos,
+  fetchGitlabOwnerRepos,
   addCredential,
   deleteCredential,
   archiveDataset,

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -182,7 +182,15 @@ const GET_JOB = gql`
     job(jobId: $jobId) {
       status
       result {
+        __typename
         ... on GitHubRepoResultType {
+          __typename
+          url
+          fork
+          hasIssues
+        }
+        ... on GitLabRepoResultType {
+          __typename
           url
           fork
           hasIssues

--- a/ui/src/components/EcosystemTree.vue
+++ b/ui/src/components/EcosystemTree.vue
@@ -247,7 +247,6 @@ export default {
         for (let dataset of datasets) {
           const mutation = await this.addDataSet(
             dataset.category,
-            "GitHub",
             dataset.url,
             project.id
           );

--- a/ui/src/components/GitlabForm.stories.js
+++ b/ui/src/components/GitlabForm.stories.js
@@ -1,0 +1,85 @@
+import GitlabForm from "./GitlabForm.vue";
+
+export default {
+  title: "GitlabForm",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <gitlab-form
+    :get-projects="getProjects"
+    :add-data-set="mockAction"
+    :get-repos="mockAction"
+    :get-token="getToken"
+    :add-token="mockAction"
+  />
+`;
+
+const projects = [
+  { name: "project-1" },
+  {
+    name: "subproject",
+    parentProject: {
+      name: "project-1"
+    }
+  },
+  { name: "project-2" }
+];
+
+export const Default = () => ({
+  components: { GitlabForm },
+  template: template,
+  data() {
+    return {
+      projects: projects
+    };
+  },
+  methods: {
+    getProjects(filters) {
+      return this.projects.filter(project =>
+        filters.term ? project.name.includes(filters.term) : true
+      );
+    },
+    mockAction() {
+      return;
+    },
+    getToken() {
+      return {
+        data: {
+          credentials: {
+            entities: [{ token: "Example token" }]
+          }
+        }
+      };
+    }
+  }
+});
+
+export const NoToken = () => ({
+  components: { GitlabForm },
+  template: template,
+  data() {
+    return {
+      projects: projects
+    };
+  },
+  methods: {
+    getProjects(filters) {
+      return this.projects.filter(project =>
+        filters.term ? project.name.includes(filters.term) : true
+      );
+    },
+    mockAction() {
+      return;
+    },
+    getToken() {
+      return {
+        data: {
+          credentials: {
+            entities: []
+          }
+        }
+      };
+    }
+  }
+});

--- a/ui/src/components/GitlabForm.vue
+++ b/ui/src/components/GitlabForm.vue
@@ -1,0 +1,326 @@
+<template>
+  <div>
+    <v-btn-toggle v-model="mode" class="mt-8" color="info" mandatory>
+      <v-btn value="single" class="button--lowercase" text outlined>
+        Add a repository
+      </v-btn>
+
+      <v-btn value="multiple" class="button--lowercase" text outlined>
+        Load all from owner
+      </v-btn>
+    </v-btn-toggle>
+    <v-form v-if="!token">
+      <h5 class="text-subtitle-2 mt-8 mb-2">Add a GitLab token (optional)</h5>
+      <p class="text-body-2 text--secondary">
+        You can add a token to access the GitLab API and a name to identify it.
+      </p>
+      <v-row class="mt-4 pb-4">
+        <v-col cols="6">
+          <v-text-field
+            v-model="newToken"
+            label="Token"
+            color="info"
+            hide-details
+            outlined
+            dense
+          />
+        </v-col>
+      </v-row>
+      <v-row class="mt-4">
+        <v-col cols="6">
+          <v-text-field
+            v-model="tokenName"
+            label="Name"
+            color="info"
+            hide-details
+            outlined
+            dense
+          />
+        </v-col>
+      </v-row>
+      <div class="d-flex justify-end pb-4">
+        <v-btn
+          :disabled="!newToken || !tokenName"
+          color="info"
+          class="button--lowercase"
+          depressed
+          @click.prevent="addCredential"
+        >
+          Save
+        </v-btn>
+      </div>
+      <v-divider class="mt-4" />
+    </v-form>
+
+    <transition name="fade" mode="out-in">
+      <v-form v-if="mode === 'single'" class="v-list" key="single">
+        <h5 class="text-subtitle-2 mt-6 mb-2">Add repositories</h5>
+        <p class="text-body-2  text--secondary">
+          Add the URL of the repository and select the data that you want to
+          analyze.
+        </p>
+        <fieldset
+          v-for="(repo, index) in repositories"
+          :key="index"
+          class="mt-4 pb-4 d-flex align-center"
+        >
+          <v-col cols="6" class="mr-6 pl-0">
+            <v-text-field
+              v-model="repo.url"
+              label="Repository URL"
+              color="info"
+              hide-details
+              outlined
+              dense
+            />
+          </v-col>
+          <v-checkbox
+            v-model="repo.selected"
+            label="Commits"
+            value="commit"
+            color="info"
+            class="mr-6"
+          ></v-checkbox>
+          <v-checkbox
+            v-model="repo.selected"
+            label="Issues"
+            value="issue"
+            color="info"
+            class="mr-6"
+          ></v-checkbox>
+          <v-checkbox
+            v-model="repo.selected"
+            label="Pull Requests"
+            value="pr"
+            color="info"
+            class="mr-8"
+          ></v-checkbox>
+          <v-tooltip right>
+            <template v-slot:activator="{ on }">
+              <v-btn
+                icon
+                color="error"
+                v-on="on"
+                @click="removeFieldset(index)"
+              >
+                <v-icon dense>mdi-minus-circle-outline</v-icon>
+              </v-btn>
+            </template>
+            <span>Remove</span>
+          </v-tooltip>
+        </fieldset>
+        <v-row class="mt-2">
+          <v-col>
+            <v-btn
+              class="button--lowercase button--secondary"
+              outlined
+              @click="addFieldset"
+            >
+              <v-icon small left>mdi-plus</v-icon>
+              Add another
+            </v-btn>
+          </v-col>
+        </v-row>
+        <div class="d-flex justify-end">
+          <project-selector
+            :get-projects="getProjects"
+            :disabled="disableSelector"
+            @selectedProject="addDatasets"
+          />
+        </div>
+      </v-form>
+      <v-form v-else>
+        <h5 class="text-subtitle-2 mt-6 mb-2">GitLab owner</h5>
+        <p class="mt-3 mb-0 text-body-2  text--secondary">
+          Load all repositories from a GitHub user, group or subgroup. You will
+          be able to add all of their commits, pull requests and issues to the
+          project or review and select each one individually.
+        </p>
+        <v-row class="mt-2">
+          <v-col cols="6">
+            <v-text-field
+              v-model="owner"
+              label="GitLab owner"
+              outlined
+              dense
+              @keydown.enter.prevent="getRepos(owner)"
+            />
+          </v-col>
+          <v-col>
+            <v-btn
+              :disabled="!owner"
+              color="info"
+              class="button--lowercase"
+              depressed
+              @click.prevent="getRepos(owner)"
+            >
+              Load
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-form>
+    </transition>
+  </div>
+</template>
+
+<script>
+import ProjectSelector from "../components/ProjectSelector";
+
+export default {
+  name: "GitlabForm",
+  components: { ProjectSelector },
+  props: {
+    getProjects: {
+      type: Function,
+      required: true
+    },
+    addDataSet: {
+      type: Function,
+      required: true
+    },
+    getRepos: {
+      type: Function,
+      required: true
+    },
+    getToken: {
+      type: Function,
+      required: true
+    },
+    addToken: {
+      type: Function,
+      required: true
+    }
+  },
+  data() {
+    return {
+      mode: "single",
+      repositories: [
+        {
+          url: "",
+          selected: ["commit", "pr", "issue"]
+        }
+      ],
+      projects: [],
+      owner: "",
+      token: null,
+      newToken: "",
+      tokenName: ""
+    };
+  },
+  computed: {
+    disableSelector() {
+      return !this.repositories.some(
+        repo => repo.url.length > 0 && repo.selected.length > 0
+      );
+    },
+    repositoriesByCategory() {
+      return this.repositories.reduce((list, current) => {
+        current.selected.forEach(category => {
+          if (current.url.length > 0) {
+            list.push({
+              category: category,
+              url: current.url
+            });
+          }
+        });
+        return list;
+      }, []);
+    }
+  },
+  methods: {
+    addFieldset() {
+      this.repositories.push({
+        url: "",
+        selected: ["commit", "pr", "issue"]
+      });
+    },
+    removeFieldset(index) {
+      this.repositories.splice(index, 1);
+    },
+    async addDatasets(project) {
+      let added = [];
+      try {
+        for (let repo of this.repositoriesByCategory) {
+          const mutation = await this.addDataSet(
+            repo.category,
+            "GitLab",
+            repo.url,
+            project.id
+          );
+          added.push(
+            Object.assign(mutation, {
+              project: project.id
+            })
+          );
+        }
+      } catch (error) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+      if (added.length !== 0) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: `Added ${added.length} datasets to ${project.title}`,
+          color: "success"
+        });
+        this.$router.push({
+          name: "project",
+          params: {
+            name: project.name,
+            ecosystemId: project.ecosystem.id
+          }
+        });
+      }
+    },
+    async addCredential() {
+      this.error = null;
+      try {
+        const response = await this.addToken("GitLab", this.newToken, this.tokenName);
+        if (response.data.addCredential.credential.id) {
+          this.newToken = "";
+          this.tokenName = "";
+          this.$store.commit("setSnackbar", {
+            isOpen: true,
+            text: `Token added successfully.`,
+            color: "success"
+          });
+        }
+      } catch (error) {
+        this.$store.commit("setSnackbar", {
+          isOpen: true,
+          text: error,
+          color: "error"
+        });
+      }
+    }
+  },
+  async mounted() {
+    const response = await this.getToken("GitLab");
+    if (response.data.credentials.entities.length > 0) {
+      this.token = response.data.credentials.entities.[0].token;
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/_buttons";
+@import "../styles/_transitions";
+@import "../styles/_variables";
+
+::v-deep .v-input--selection-controls__input + .v-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+fieldset {
+  border: 0;
+
+  &:not(:last-of-type) {
+    border-bottom: thin solid $border-color;
+  }
+}
+</style>

--- a/ui/src/components/RepositoryTable.stories.js
+++ b/ui/src/components/RepositoryTable.stories.js
@@ -1,12 +1,12 @@
-import GitHubTable from "./GitHubTable.vue";
+import RepositoryTable from "./RepositoryTable.vue";
 
 export default {
-  title: "GitHubTable",
+  title: "RepositoryTable",
   excludeStories: /.*Data$/
 };
 
 const template = `
-  <git-hub-table
+  <repository-table
     :items="items"
     :get-projects="getProjects"
     :add-data-set="addDataSet"
@@ -15,7 +15,7 @@ const template = `
 `;
 
 export const Default = () => ({
-  components: { GitHubTable },
+  components: { RepositoryTable },
   template: template,
   data() {
     return {
@@ -70,7 +70,7 @@ export const Default = () => ({
 });
 
 export const Loading = () => ({
-  components: { GitHubTable },
+  components: { RepositoryTable },
   template: template,
   data() {
     return {
@@ -95,7 +95,7 @@ export const Loading = () => ({
 });
 
 export const NoResults = () => ({
-  components: { GitHubTable },
+  components: { RepositoryTable },
   template: template,
   data() {
     return {

--- a/ui/src/components/RepositoryTable.vue
+++ b/ui/src/components/RepositoryTable.vue
@@ -124,7 +124,7 @@
 import ProjectSelector from "../components/ProjectSelector";
 
 export default {
-  name: "GitHubTable",
+  name: "RepositoryTable",
   components: { ProjectSelector },
   props: {
     items: {
@@ -199,42 +199,21 @@ export default {
       const dragImage = document.querySelector(".dragged-item");
       event.dataTransfer.setDragImage(dragImage, 0, 0);
     },
-    async loadProjects(term) {
-      const response = await this.getProjects(term);
-      if (response) {
-        this.projects = response;
-        this.projects.forEach(res => {
-          Object.assign(res, { path: this.getPath(res) });
-        });
-      }
-    },
-    getPath(project) {
-      const path = [project.name];
-
-      function findParents(parent) {
-        if (parent) {
-          path.push(parent.name);
-          findParents(parent.parentProject);
-        }
-      }
-
-      findParents(project.parentProject);
-
-      return path
-        .reverse()
-        .toString()
-        .replace(/,/g, " / ");
-    },
     async addDatasets(project) {
       this.showMenu = false;
       this.error = null;
       let added = [];
 
+      this.$store.commit("setSnackbar", {
+        isOpen: true,
+        text: `Adding datasets to ${project.title}`,
+        color: "info"
+      });
+
       try {
         for (let selected of this.selectedByCategory) {
           const mutation = await this.addDataSet(
             selected.category,
-            "GitHub",
             selected.url,
             project.id
           );
@@ -246,6 +225,9 @@ export default {
         }
       } catch (error) {
         this.error = error;
+        this.$store.commit("setSnackbar", {
+          isOpen: false
+        });
       }
 
       if (added.length !== 0) {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -7,7 +7,10 @@ import VueApollo from "vue-apollo";
 import VueRouter from "vue-router";
 import { ApolloClient } from "apollo-client";
 import { createHttpLink } from "apollo-link-http";
-import { InMemoryCache } from "apollo-cache-inmemory";
+import {
+  InMemoryCache,
+  IntrospectionFragmentMatcher
+} from "apollo-cache-inmemory";
 import Cookies from "js-cookie";
 import { ApolloLink } from "apollo-link";
 
@@ -25,8 +28,17 @@ const httpLink = createHttpLink({
   credentials: "include"
 });
 
+// Match types for fragments and unions (... on Type)
+const fragmentMatcher = new IntrospectionFragmentMatcher({
+  introspectionQueryResultData: {
+    __schema: {
+      types: []
+    }
+  }
+});
+
 // Cache implementation
-const cache = new InMemoryCache();
+const cache = new InMemoryCache({ fragmentMatcher });
 
 const AuthLink = (operation, next) => {
   const token = csrftoken;

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -67,9 +67,9 @@ const router = new Router({
           component: () => import("../views/AddDatasources")
         },
         {
-          name: "github-datasources",
-          path: "/datasources/github/:jobID",
-          component: () => import("../views/GithubDatasources")
+          name: "datasources-job",
+          path: "/datasources/:datasource/:jobID",
+          component: () => import("../views/DatasourcesJob")
         },
         {
           name: "credentials",

--- a/ui/src/views/AddCredentials.vue
+++ b/ui/src/views/AddCredentials.vue
@@ -58,7 +58,7 @@ export default {
   name: "AddCredentials",
   data() {
     return {
-      sources: ["GitHub"],
+      sources: ["GitHub", "GitLab"],
       datasource: null,
       token: "",
       name: ""

--- a/ui/src/views/AddDatasources.vue
+++ b/ui/src/views/AddDatasources.vue
@@ -9,7 +9,7 @@
         <v-icon dense left>mdi-github</v-icon>
         GitHub
       </v-tab>
-      <v-tab-item transition="fade">
+      <v-tab-item transition="fade" reverse-transition="fade">
         <div v-if="isLoading" class="d-flex justify-center">
           <v-progress-circular
             :size="50"
@@ -26,6 +26,28 @@
           :add-token="addToken"
         />
       </v-tab-item>
+
+      <v-tab class="button--lowercase button--secondary">
+        <v-icon dense left>mdi-gitlab</v-icon>
+        GitLab
+      </v-tab>
+      <v-tab-item transition="fade" reverse-transition="fade" eager>
+        <div v-if="isLoading" class="d-flex justify-center">
+          <v-progress-circular
+            :size="50"
+            color="primary"
+            indeterminate
+          ></v-progress-circular>
+        </div>
+        <gitlab-form
+          v-else
+          :get-projects="getProjects"
+          :add-data-set="addDataSet"
+          :get-repos="getGitlabOwnerRepos"
+          :get-token="getToken"
+          :add-token="addToken"
+        />
+      </v-tab-item>
     </v-tabs>
   </section>
 </template>
@@ -35,13 +57,15 @@ import { getProjects, getDatasourceCredentials } from "../apollo/queries";
 import {
   addDataSet,
   addCredential,
-  fetchGithubOwnerRepos
+  fetchGithubOwnerRepos,
+  fetchGitlabOwnerRepos
 } from "../apollo/mutations";
 import GithubForm from "../components/GithubForm";
+import GitlabForm from "../components/GitlabForm";
 
 export default {
   name: "AddDatasources",
-  components: { GithubForm },
+  components: { GithubForm, GitlabForm },
   data() {
     return {
       isLoading: false
@@ -72,8 +96,24 @@ export default {
       const response = await fetchGithubOwnerRepos(this.$apollo, owner);
       if (response.data.fetchGithubOwnerRepos.jobId) {
         this.$router.push({
-          name: "github-datasources",
-          params: { jobID: response.data.fetchGithubOwnerRepos.jobId }
+          name: "datasources-job",
+          params: {
+            jobID: response.data.fetchGithubOwnerRepos.jobId,
+            datasource: "github"
+          }
+        });
+      }
+    },
+    async getGitlabOwnerRepos(owner) {
+      this.isLoading = true;
+      const response = await fetchGitlabOwnerRepos(this.$apollo, owner);
+      if (response.data.fetchGitlabOwnerRepos.jobId) {
+        this.$router.push({
+          name: "datasources-job",
+          params: {
+            jobID: response.data.fetchGitlabOwnerRepos.jobId,
+            datasource: "gitlab"
+          }
         });
       }
     },

--- a/ui/src/views/DatasourcesJob.vue
+++ b/ui/src/views/DatasourcesJob.vue
@@ -15,7 +15,7 @@
       {{ error }}
     </v-alert>
 
-    <git-hub-table
+    <repository-table
       :items="items"
       :add-data-set="addDataSet"
       :get-projects="getProjects"
@@ -42,11 +42,11 @@
 <script>
 import { getProjects, GET_JOB } from "../apollo/queries";
 import { addDataSet } from "../apollo/mutations";
-import GitHubTable from "../components/GitHubTable";
+import RepositoryTable from "../components/RepositoryTable";
 
 export default {
-  name: "GithubDatasources",
-  components: { GitHubTable },
+  name: "DatasourcesJob",
+  components: { RepositoryTable },
   data() {
     return {
       items: [],
@@ -55,6 +55,9 @@ export default {
     };
   },
   computed: {
+    datasourceName() {
+      return this.$route.params.datasource;
+    },
     jobID() {
       return this.$route.params.jobID;
     }
@@ -66,11 +69,11 @@ export default {
         return response.data.projects.entities;
       }
     },
-    async addDataSet(category, datasourceName, uri, projectId, filters = {}) {
+    async addDataSet(category, uri, projectId, filters = {}) {
       const response = await addDataSet(
         this.$apollo,
         category,
-        datasourceName,
+        this.datasourceName,
         uri,
         projectId,
         filters

--- a/ui/src/views/DatasourcesJob.vue
+++ b/ui/src/views/DatasourcesJob.vue
@@ -96,16 +96,21 @@ export default {
         };
       },
       result(result) {
-        // Stop running the query if its status is 'finished'
-        if (result.data && result.data.job.status === "finished") {
+        // Stop running the query if its status is 'finished' or 'failed'
+        if (
+          (result.data && result.data.job.status === "finished") ||
+          result.data.job.status === "failed"
+        ) {
           this.$apollo.queries.job.stopPolling();
-          this.items = result.data.job.result;
-          this.error = "";
           this.isLoading = false;
 
-          if (result.data.job.errors) {
+          if (result.data.job.errors.length > 0) {
             this.error = result.data.job.errors;
+            return;
           }
+
+          this.items = result.data.job.result;
+          this.error = "";
         }
       },
       error(error) {

--- a/ui/src/views/Sidebar.vue
+++ b/ui/src/views/Sidebar.vue
@@ -187,11 +187,11 @@ export default {
         });
       }
     },
-    async addDataSet(category, datasourceName, uri, projectId, filters = {}) {
+    async addDataSet(category, uri, projectId, filters = {}) {
       const response = await addDataSet(
         this.$apollo,
         category,
-        datasourceName,
+        this.$route.params.datasource,
         uri,
         projectId,
         filters


### PR DESCRIPTION
Adds a tab to add GitLab repositories on the `/datasources` view. Users can add repositories one by one or fetch all from a user or group.