### PR TITLE
Improve performance in queries when adding repositories from organizations

### DIFF
--- a/releases/unreleased/improve-performance-when-adding-organizations.yml
+++ b/releases/unreleased/improve-performance-when-adding-organizations.yml
@@ -1,0 +1,9 @@
+---
+title: Improve performance when adding organizations
+category: performance
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 104
+notes: >
+    This change allows to decrease the number of queries
+    to the server and reduce the time when adding a lot 
+    of repositories from a single organization.

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -116,6 +116,27 @@ const ADD_DATASET = gql`
   }
 `;
 
+const ADD_DATASETS = gql`
+  mutation addDatasets(
+    $projectId: ID!
+    $datasourceName: String
+    $datasets: [DatasetInputType]
+  ) {
+    addDatasets(
+      projectId: $projectId
+      datasourceName: $datasourceName
+      datasets: $datasets
+    ) {
+      datasets {
+        id
+        datasource {
+          uri
+        }
+      }
+    }
+  }
+`;
+
 const DELETE_DATASET = gql`
   mutation deleteDataset($id: ID!) {
     deleteDataset(id: $id) {
@@ -298,6 +319,23 @@ const addDataSet = (
   return response;
 };
 
+const addDataSets = (
+  apollo,
+  projectId,
+  datasourceName,
+  datasets
+) => {
+  const response = apollo.mutate({
+    mutation: ADD_DATASETS,
+    variables: {
+      projectId: projectId,
+      datasourceName: datasourceName,
+      datasets: datasets
+    }
+  });
+  return response;
+};
+
 const fetchGithubOwnerRepos = (apollo, owner) => {
   const response = apollo.mutate({
     mutation: FETCH_GITHUB_OWNER_REPOS,
@@ -380,6 +418,7 @@ export {
   deleteEcosystem,
   tokenAuth,
   addDataSet,
+  addDataSets,
   deleteDataset,
   fetchGithubOwnerRepos,
   fetchGitlabOwnerRepos,

--- a/ui/src/components/RepositoryTable.vue
+++ b/ui/src/components/RepositoryTable.vue
@@ -135,7 +135,7 @@ export default {
       type: Function,
       required: true
     },
-    addDataSet: {
+    addDataSets: {
       type: Function,
       required: true
     },
@@ -211,18 +211,7 @@ export default {
       });
 
       try {
-        for (let selected of this.selectedByCategory) {
-          const mutation = await this.addDataSet(
-            selected.category,
-            selected.url,
-            project.id
-          );
-          added.push(
-            Object.assign(mutation, {
-              project: project.id
-            })
-          );
-        }
+        added = await this.addDataSets(this.selectedByCategory, project.id);
       } catch (error) {
         this.error = error;
         this.$store.commit("setSnackbar", {


### PR DESCRIPTION
Adding large organizations which has over 2K repositories needs 6K requests (issues, prs and commits).

The idea of this commit is to add the datasets in bulk requests of 100, grouping common data in requests like project_id and datasource type.

Related to https://github.com/chaoss/grimoirelab-bestiary/issues/98